### PR TITLE
Add recent ABC, Nature, and ABC PM media coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Stack: Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS 4. Config is 
 
 ## Project overview
 
-Marine biology lab site for Professor Jodie Rummer at James Cook University: research, team, publications, media, podcast, gallery, and Physioshark.
+Marine biology lab site for Professor Jodie Rummer at James Cook University: research, team, publications, media, podcast, blog, gallery, and Physioshark.
 
 Sister sites: [jodierummer.com](https://jodierummer.com), [physioshark.org](https://physioshark.org). Spell **RummerLab** with no space.
 
@@ -44,6 +44,7 @@ If you suspect a security issue, run `snyk test`.
 - Await `params` and `searchParams`. Use the platform `fetch` API (not `node-fetch`).
 - Early returns, DRY, `handle` prefix on event handlers (`handleClick`).
 - Style with Tailwind. Support light and dark classes already used on the site.
+- Media cards live in `data/media.ts`. `url` is optional. Use `sources` for syndications of the same story; the primary `source`/`url` should be the strongest public outlet. Clickable source tags open that outlet's URL.
 - Use `git mv` when moving files.
 - Complete the change: no TODOs or placeholders.
 

--- a/app/media/MediaCoverageList.tsx
+++ b/app/media/MediaCoverageList.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { DEFAULT_SCHOLAR_ID } from "@/lib/news";
-import type { MediaItem } from "@/types/media";
+import { getMediaSources, type MediaItem } from "@/types/media";
 import { ArticleImage } from "./ArticleImage";
 
 const DEFAULT_LIMIT = 100;
@@ -27,7 +27,7 @@ const getSourceColors = (sourceType: string): { bgColor: string; textColor: stri
   }
 };
 
-const hasValidUrl = (url: string): boolean => {
+const hasValidUrl = (url?: string): boolean => {
   if (!url || typeof url !== "string") return false;
   const trimmed = url.trim();
   if (!trimmed) return false;
@@ -103,7 +103,7 @@ export function MediaCoverageList(props: Props) {
   return (
     <div className="grid gap-8">
       {sortedItems.map((article, index) => {
-        const { bgColor, textColor } = getSourceColors(article.sourceType);
+        const outlets = getMediaSources(article);
         const urlOk = hasValidUrl(article.url);
 
         return (
@@ -114,11 +114,36 @@ export function MediaCoverageList(props: Props) {
             <div className="flex flex-col md:flex-row">
               {article.image && <ArticleImage image={article.image} />}
               <div className="flex-1 p-6">
-                <span
-                  className={`inline-block px-2 py-1 text-sm font-medium ${bgColor} ${textColor} rounded-sm mb-4`}
-                >
-                  {article.source}
-                </span>
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {outlets.map((outlet) => {
+                    const { bgColor, textColor } = getSourceColors(
+                      outlet.sourceType ?? article.sourceType
+                    );
+                    const outletUrlOk = hasValidUrl(outlet.url);
+                    const tagClassName = `inline-block px-2 py-1 text-sm font-medium ${bgColor} ${textColor} rounded-sm`;
+
+                    if (!outletUrlOk) {
+                      return (
+                        <span key={outlet.name} className={tagClassName}>
+                          {outlet.name}
+                        </span>
+                      );
+                    }
+
+                    return (
+                      <a
+                        key={outlet.name}
+                        href={outlet.url}
+                        className={`${tagClassName} hover:opacity-80 transition-opacity`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`${outlet.name} (opens in new tab)`}
+                      >
+                        {outlet.name}
+                      </a>
+                    );
+                  })}
+                </div>
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
                   {urlOk ? (
                     <a

--- a/data/media.ts
+++ b/data/media.ts
@@ -416,6 +416,33 @@ export const mediaItems: MediaItem[] = [
         url: "",
         date: '2026-05-26',
         sourceType: 'ABC News'
+    },
+    {
+        type: 'article',
+        source: "ABC News",
+        title: "Shark cull will not improve beach safety or reduce attacks, marine biologists say",
+        description: "James Cook University professor of marine biology Jodie Rummer said there was \"no scientific evidence that culling programs work to remove problematic animals\" after the Coogee Beach shark attack. \"It's not that there are more sharks in the water, it's just that they're in different places at different times than they have [been] historically,\" she said.",
+        url: "https://www.abc.net.au/news/2026-06-16/shark-cull-wont-fix-sydney-beach-safety-marine-biologists-say/106797826",
+        date: '2026-06-16',
+        sourceType: 'ABC News'
+    },
+    {
+        type: 'article',
+        source: "Nature",
+        title: "Oceans in Asia smash heat records — what it means for extreme weather",
+        description: "Almost all of Asia's oceans experienced marine heatwaves at the same time in 2025, which Jodie Rummer, a marine biologist at James Cook University, said is alarming because so much of the region was affected simultaneously.",
+        url: "https://www.nature.com/articles/d41586-026-01938-2",
+        date: '2026-06-18',
+        sourceType: 'Other'
+    },
+    {
+        type: 'interview',
+        source: "ABC Radio",
+        title: "Shark deterrent surfboard fin in development",
+        description: "ABC PM segment on a University of Wollongong surfboard fin with embedded shark-deterrent technology, featuring Dr Jodie Rummer, Professor of Marine Biology at James Cook University.",
+        url: "https://www.abc.net.au/listen/programs/pm/shark-deterrent-surfboard-fin-in-development-/106569176",
+        date: '2026-04-15',
+        sourceType: 'ABC News'
     }
 ];
 

--- a/data/media.ts
+++ b/data/media.ts
@@ -443,6 +443,51 @@ export const mediaItems: MediaItem[] = [
         url: "https://www.abc.net.au/listen/programs/pm/shark-deterrent-surfboard-fin-in-development-/106569176",
         date: '2026-04-15',
         sourceType: 'ABC News'
+    },
+    {
+        type: 'article',
+        source: "Cosmos Magazine",
+        title: "Childhood dreams of breathing underwater inspired fish physiology career",
+        description: "A gift of snorkelling gear and a trip to Florida was all it took to hook 8-year-old Jodie Rummer into marine science. \"Wow, that was it for me!\" recalls Rummer, now Professor of Marine Science at James Cook University.",
+        url: "https://cosmosmagazine.com/nature/marine-life/jodie-rummer-fish-physiology/",
+        date: '2025-08-17',
+        sourceType: 'Other'
+    },
+    {
+        type: 'article',
+        source: "news.com.au",
+        title: "Shark culling protects politicians more than people, experts say as calls for a cull reignite",
+        description: "James Cook University professor of marine biology Jodie Rummer said, \"I think that we've had enough lessons in all of science and all of biology that show us that when we remove predators from an ecosystem then it disrupts the whole ecosystem … and it takes us decades, if not a century, to fix it.\"",
+        url: "https://www.news.com.au/technology/science/animals/shark-culling-protects-politicians-more-than-people-experts-say-as-calls-for-a-cull-reignite/news-story/a584820c799b4c99326bed1ab69c9741",
+        date: '2026-06-21',
+        sourceType: 'Other'
+    },
+    {
+        type: 'article',
+        source: "RNZ",
+        title: "Shark cull will not improve beach safety or reduce attacks, marine biologists say",
+        description: "James Cook University professor of marine biology Jodie Rummer said there was \"no scientific evidence that culling programs work to remove problematic animals\" and that sharks are \"in different places at different times than they have [been] historically.\"",
+        url: "https://www.rnz.co.nz/news/world/598308/shark-cull-will-not-improve-beach-safety-or-reduce-attacks-marine-biologists-say",
+        date: '2026-06-16',
+        sourceType: 'Other'
+    },
+    {
+        type: 'article',
+        source: "Popular Mechanics",
+        title: "Scientists Found a Creature That's Breaking the Rules of Reproduction",
+        description: "\"Reproduction is the ultimate investment … you are literally building new life from scratch,\" Jodie Rummer, senior author of the James Cook University walking-shark study, said. \"We expected that when sharks make this complex egg, their energy use would shoot up.\" There was no uptick: \"it was completely flat.\"",
+        url: "https://www.popularmechanics.com/science/animals/a70081203/walking-shark-reproduction/",
+        date: '2026-01-27',
+        sourceType: 'Other'
+    },
+    {
+        type: 'article',
+        source: "Frontiers in Fish Science",
+        title: "Inclusive science for a changing ocean: Gender equity in elasmobranch research",
+        description: "A Perspective co-authored by Jodie L. Rummer arguing that gender equity and diverse leadership are essential to the intellectual robustness of shark and ray science, not optional extras.",
+        url: "https://www.frontiersin.org/journals/fish-science/articles/10.3389/frish.2026.1816786/full",
+        date: '2026-06-23',
+        sourceType: 'Research Highlight'
     }
 ];
 

--- a/data/media.ts
+++ b/data/media.ts
@@ -1,533 +1,667 @@
-import type { MediaItem } from "@/types/media";
+import type { MediaItem, MediaSource } from '@/types/media'
 
-export type { MediaItem };
+export type { MediaItem, MediaSource }
+export { getMediaSources } from '@/types/media'
+
+const newsCorpCullSyndicates: MediaSource[] = [
+    { name: 'Yahoo Lifestyle Australia', title: "One thing that won't solve shark attacks" },
+    { name: 'Yahoo News Australia', title: "One thing that won't solve shark attacks" },
+    { name: 'Herald Sun' },
+    { name: 'The Courier Mail' },
+    { name: 'The Australian' },
+    { name: 'Townsville Bulletin' },
+    { name: 'Cairns Post' },
+    { name: 'PerthNow' },
+    { name: 'Daily Telegraph' },
+    { name: 'Adelaide Now' },
+    { name: 'Geelong Advertiser' },
+    { name: 'Gold Coast Bulletin' },
+    { name: 'The Mercury' },
+    { name: 'Weekly Times Now' },
+    { name: 'Toowoomba Chronicle' },
+    { name: 'Northern Territory News' },
+    { name: 'West Australian' },
+    { name: 'South Western Times' },
+    { name: 'Pilbara News' },
+    { name: 'Great Southern Herald' },
+    { name: 'Kalgoorlie Miner' },
+    { name: 'Augusta-Margaret River Times' },
+    { name: 'Bunbury Herald' },
+    { name: 'Harvey-Waroona Reporter' },
+    { name: 'Busselton Dunsborough Times' },
+    { name: 'Manjimup-Bridgetown Times' },
+    { name: 'Midwest Times' },
+    { name: 'Countryman' },
+    { name: 'North West Telegraph' },
+    { name: 'Narrogin Observer' },
+    { name: 'Sound Telegraph' },
+    { name: 'Broome Advertiser' },
+    { name: 'Geraldton Guardian' },
+]
+
+const hullHeadsNewsCorpSyndicates: MediaSource[] = [
+    { name: 'Herald Sun' },
+    { name: 'The Courier Mail' },
+    { name: 'Daily Telegraph' },
+    { name: 'Adelaide Now' },
+    { name: 'Geelong Advertiser' },
+    { name: 'Gold Coast Bulletin' },
+    { name: 'The Mercury' },
+    { name: 'Weekly Times Now' },
+    { name: 'Toowoomba Chronicle' },
+    { name: 'Northern Territory News' },
+    { name: 'Cassowary Coast' },
+]
 
 export const mediaItems: MediaItem[] = [
     {
         type: 'article',
-        source: "The Conversation",
-        title: "How fish can still be part of a more sustainable food future",
-        description: "Exploring sustainable fishing practices and the future of marine food sources.",
-        url: "https://theconversation.com/profiles/jodie-rummer-98570/articles",
+        source: 'The Conversation',
+        title: 'How fish can still be part of a more sustainable food future',
+        description:
+            'Exploring sustainable fishing practices and the future of marine food sources.',
+        url: 'https://theconversation.com/profiles/jodie-rummer-98570/articles',
         date: '2024-01-15',
-        sourceType: 'The Conversation'
+        sourceType: 'The Conversation',
     },
     {
         type: 'interview',
-        source: "ABC News",
-        title: "Climate Change Impact on Great Barrier Reef Fish",
-        description: "Discussion on how rising ocean temperatures affect fish populations in the Great Barrier Reef.",
-        url: "https://www.abc.net.au/news/",
+        source: 'ABC News',
+        title: 'Climate Change Impact on Great Barrier Reef Fish',
+        description:
+            'Discussion on how rising ocean temperatures affect fish populations in the Great Barrier Reef.',
+        url: 'https://www.abc.net.au/news/',
         date: '2023-12-10',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'podcast',
-        source: "Science Friday",
-        title: "Marine Science and Conservation",
-        description: "Discussion on latest research findings and conservation efforts in marine biology.",
-        url: "https://www.sciencefriday.com/",
+        source: 'Science Friday',
+        title: 'Marine Science and Conservation',
+        description:
+            'Discussion on latest research findings and conservation efforts in marine biology.',
+        url: 'https://www.sciencefriday.com/',
         date: '2023-11-20',
-        sourceType: 'Science Podcast'
+        sourceType: 'Science Podcast',
     },
     {
         type: 'press',
-        source: "JCU News",
-        title: "New Findings on Shark Nursery Habitats",
-        description: "Latest research findings on shark nursery habitats in Moorea, French Polynesia.",
-        url: "https://www.jcu.edu.au/news",
+        source: 'JCU News',
+        title: 'New Findings on Shark Nursery Habitats',
+        description:
+            'Latest research findings on shark nursery habitats in Moorea, French Polynesia.',
+        url: 'https://www.jcu.edu.au/news',
         date: '2023-10-05',
-        sourceType: 'Research Highlight'
+        sourceType: 'Research Highlight',
     },
     {
         type: 'article',
-        source: "ABC News",
-        title: "Highest number of January shark attacks in NSW for a decade, according to national database",
-        description: "Jodie Rummer, a marine biology professor at James Cook University, says the recent spate of attacks \"is even shocking to me\".",
-        url: "https://www.abc.net.au/news/2026-01-21/shark-attack-numbers-in-nsw-australian-shark-incident-database/106249078",
+        source: 'ABC News',
+        title: 'Highest number of January shark attacks in NSW for a decade, according to national database',
+        description:
+            'Jodie Rummer, a marine biology professor at James Cook University, says the recent spate of attacks "is even shocking to me".',
+        url: 'https://www.abc.net.au/news/2026-01-21/shark-attack-numbers-in-nsw-australian-shark-incident-database/106249078',
         date: '2026-01-21',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'article',
-        source: "Phys.org",
-        title: "Walking sharks break biology reproduction rules",
-        description: "JCU's shark physiology research team, led by Professor Jodie Rummer, finds that walking sharks can reproduce and lay eggs without any measurable rise in energy use.",
-        url: "https://phys.org/news/2026-01-sharks-biology-reproduction.html",
+        source: 'Phys.org',
+        title: 'Walking sharks break biology reproduction rules',
+        description:
+            "JCU's shark physiology research team, led by Professor Jodie Rummer, finds that walking sharks can reproduce and lay eggs without any measurable rise in energy use.",
+        url: 'https://phys.org/news/2026-01-sharks-biology-reproduction.html',
         date: '2026-01-21',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Australasian Leisure Management Magazine",
-        title: "NSW shark incidents highlight challenges for Coastal Safety, Risk Communication and Beach Management",
-        description: "Professor Rummer highlighted \"It is important to frame these as shark–human interactions rather than deliberate attacks. Sharks do not target people.\"",
-        url: "https://www.ausleisure.com.au/news/nsw-shark-incidents-highlight-challenges-for-coastal-safety-risk-communication-and-beach-management",
+        source: 'Australasian Leisure Management Magazine',
+        title: 'NSW shark incidents highlight challenges for Coastal Safety, Risk Communication and Beach Management',
+        description:
+            'Professor Rummer highlighted "It is important to frame these as shark–human interactions rather than deliberate attacks. Sharks do not target people."',
+        url: 'https://www.ausleisure.com.au/news/nsw-shark-incidents-highlight-challenges-for-coastal-safety-risk-communication-and-beach-management',
         date: '2026-01-21',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Tech Explorist",
-        title: "Walking sharks break the rules of reproductive energy costs",
-        description: "Research by Professor Jodie Rummer assessing the metabolic and physiological costs of oviparity in the epaulette shark (Hemiscyllium ocellatum).",
-        url: "https://www.techexplorist.com/walking-sharks-break-rules-reproductive-energy-costs/101872/",
+        source: 'Tech Explorist',
+        title: 'Walking sharks break the rules of reproductive energy costs',
+        description:
+            'Research by Professor Jodie Rummer assessing the metabolic and physiological costs of oviparity in the epaulette shark (Hemiscyllium ocellatum).',
+        url: 'https://www.techexplorist.com/walking-sharks-break-rules-reproductive-energy-costs/101872/',
         date: '2026-01-21',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Green Matters",
+        source: 'Green Matters',
         title: "These Walking Sharks Defy Biology's Reproduction Rules, Scientists Reveal",
-        description: "Professor Rummer, who led James Cook University's shark physiology research team, said there was no uptick in energy use during reproduction.",
-        url: "https://www.greenmatters.com/pn/these-walking-sharks-defy-biologys-reproduction-rules-scientists-reveal",
+        description:
+            "Professor Rummer, who led James Cook University's shark physiology research team, said there was no uptick in energy use during reproduction.",
+        url: 'https://www.greenmatters.com/pn/these-walking-sharks-defy-biologys-reproduction-rules-scientists-reveal',
         date: '2026-01-21',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'podcast',
-        source: "Where The Ocean Meets",
+        source: 'Where The Ocean Meets',
         title: "Climate Change is Destroying the Great Barrier Reef | Here's Why",
-        description: "There's a short interactive quiz built into this episode—take a moment to test your knowledge about fish physiology. Witness firsthand the devastating impact of 31-degree water temperatures as Dr. Jodie Rummer describes the beginning of coral bleaching on the Great Barrier Reef. This episode dives into the physiology of the climate crisis—VO2 max, heart rate, oxygen levels, and how fish adapt when the ocean gets too hot—and what it means for the future of ocean life.",
-        url: "https://www.youtube.com/watch?v=uD67tHh3RWA",
+        description:
+            "There's a short interactive quiz built into this episode—take a moment to test your knowledge about fish physiology. Witness firsthand the devastating impact of 31-degree water temperatures as Dr. Jodie Rummer describes the beginning of coral bleaching on the Great Barrier Reef. This episode dives into the physiology of the climate crisis—VO2 max, heart rate, oxygen levels, and how fish adapt when the ocean gets too hot—and what it means for the future of ocean life.",
+        url: 'https://www.youtube.com/watch?v=uD67tHh3RWA',
         date: '2026-02-26',
-        sourceType: 'Science Podcast'
+        sourceType: 'Science Podcast',
     },
     {
         type: 'article',
-        source: "Cairns Post",
-        title: "Cairns Post coverage",
-        description: "Media coverage featuring Dr. Jodie Rummer",
-        url: "",
+        source: 'Cairns Post',
+        title: 'Cairns Post coverage',
+        description: 'Media coverage featuring Dr. Jodie Rummer',
+        url: '',
         date: '2026-01-16',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Cairns Post",
-        title: "Far North Qld shark attack victim at Hull Heads identified as Michael Jensz",
-        description: "Professor Jodie Rummer said shark management needs to be evidence-based, not driven by fear or retaliation, after the fatal Hull Heads shark attack.",
-        url: "https://www.cairnspost.com.au/news/cassowary-coast/far-north-qld-shark-attack-victim-at-hull-heads-identified-as-michael-jensz/news-story/17a46d4315b000c949c1a45c73b14bbf",
+        source: 'Cairns Post',
+        title: 'Far North Qld shark attack victim at Hull Heads identified as Michael Jensz',
+        description:
+            'Professor Jodie Rummer said shark management needs to be evidence-based, not driven by fear or retaliation, after the fatal Hull Heads shark attack.',
+        url: 'https://www.cairnspost.com.au/news/cassowary-coast/far-north-qld-shark-attack-victim-at-hull-heads-identified-as-michael-jensz/news-story/17a46d4315b000c949c1a45c73b14bbf',
         date: '2026-05-25',
-        sourceType: 'Other'
+        sourceType: 'Other',
+        sources: hullHeadsNewsCorpSyndicates,
     },
     {
         type: 'article',
-        source: "news.com.au",
-        title: "Bob Katter calls for shark culling after horror attack leaves Cairns spearfisherman dead",
-        description: "Jodie Rummer said there is no scientifically robust justification for shark culling after the fatal Hull Heads shark-human interaction.",
-        url: "https://www.news.com.au/travel/travel-updates/incidents/bob-katter-calls-for-shark-culling-after-horror-attack-leaves-cairns-spearfisherman-dead/news-story/56ecba20db4aacb882e84930e8df0d33",
+        source: 'news.com.au',
+        title: 'Bob Katter calls for shark culling after horror attack leaves Cairns spearfisherman dead',
+        description:
+            'Jodie Rummer said there is no scientifically robust justification for shark culling after the fatal Hull Heads shark-human interaction.',
+        url: 'https://www.news.com.au/travel/travel-updates/incidents/bob-katter-calls-for-shark-culling-after-horror-attack-leaves-cairns-spearfisherman-dead/news-story/56ecba20db4aacb882e84930e8df0d33',
         date: '2026-05-25',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "ABC News",
+        source: 'ABC News',
         title: "Death of Michael Jensz in Qld shark attack brings dangers of spearfishing 'close to home'",
-        description: "Jodie Rummer disputed claims that shark numbers are increasing and said culling is not a solution after the fatal Far North Queensland spearfishing incident.",
-        url: "https://www.abc.net.au/news/2026-05-25/queensland-spearfisher-shark-attack-victim-identified/106718104",
+        description:
+            'Jodie Rummer disputed claims that shark numbers are increasing and said culling is not a solution after the fatal Far North Queensland spearfishing incident.',
+        url: 'https://www.abc.net.au/news/2026-05-25/queensland-spearfisher-shark-attack-victim-identified/106718104',
         date: '2026-05-25',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'article',
-        source: "WEB OZ Arab Media",
-        title: "Shark Attack Claims Life of Queensland Spearfisher",
-        description: "Online coverage of the Michael Jensz shark fatality, part of the JCU media monitoring summary that also tracked Jodie Rummer's comments on evidence-based shark management.",
-        url: "",
+        source: 'WEB OZ Arab Media',
+        title: 'Shark Attack Claims Life of Queensland Spearfisher',
+        description:
+            "Online coverage of the Michael Jensz shark fatality, part of the JCU media monitoring summary that also tracked Jodie Rummer's comments on evidence-based shark management.",
+        url: '',
         date: '2026-05-25',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "This is Money",
+        source: 'This is Money',
         title: "Pictured: Spearfisher tragically killed in horrific shark attack near Queensland's Great Barrier Reef",
-        description: "Syndicated online coverage of the Kennedy Shoal spearfishing fatality included in the JCU media monitoring summary alongside Jodie Rummer's shark-management commentary.",
-        url: "https://www.thisismoney.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html",
+        description:
+            "Syndicated online coverage of the Kennedy Shoal spearfishing fatality included in the JCU media monitoring summary alongside Jodie Rummer's shark-management commentary.",
+        url: 'https://www.thisismoney.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html',
         date: '2026-05-25',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Daily Mail Australia",
+        source: 'Daily Mail Australia',
         title: "Pictured: Spearfisher tragically killed in horrific shark attack on Queensland's Great Barrier Reef",
-        description: "Daily Mail Australia coverage of the Michael Jensz shark fatality included in the JCU online media summary alongside Jodie Rummer's shark-management commentary.",
-        url: "https://www.dailymail.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html",
+        description:
+            "Daily Mail Australia coverage of the Michael Jensz shark fatality included in the JCU online media summary alongside Jodie Rummer's shark-management commentary.",
+        url: 'https://www.dailymail.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html',
         date: '2026-05-25',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "DIVE Magazine",
-        title: "Great Barrier Reef spearfisher killed by shark bite",
-        description: "DIVE Magazine cited Jodie Rummer on evidence around shark-culling programmes after the fatal Kennedy Shoal spearfishing incident.",
-        url: "https://divemagazine.com/scuba-diving-news/great-barrier-reef-spearfisher-killed-by-shark-bite",
+        source: 'DIVE Magazine',
+        title: 'Great Barrier Reef spearfisher killed by shark bite',
+        description:
+            'DIVE Magazine cited Jodie Rummer on evidence around shark-culling programmes after the fatal Kennedy Shoal spearfishing incident.',
+        url: 'https://divemagazine.com/scuba-diving-news/great-barrier-reef-spearfisher-killed-by-shark-bite',
         date: '2026-05-27',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Courier Mail",
-        title: "Shark victim an action man",
-        description: "Print coverage of the Michael Jensz shark fatality quoting Jodie Rummer on evidence-based shark management and shark-human interactions.",
-        url: "",
+        source: 'Courier Mail',
+        title: 'Shark victim an action man',
+        description:
+            'Print coverage of the Michael Jensz shark fatality quoting Jodie Rummer on evidence-based shark management and shark-human interactions.',
+        url: '',
         date: '2026-05-26',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Cairns Post",
-        title: "DIED WITH MATES",
-        description: "Print coverage of the Hull Heads shark fatality quoting Jodie Rummer on shark behaviour, shark-human interactions, and evidence-based management.",
-        url: "",
+        source: 'Cairns Post',
+        title: 'DIED WITH MATES',
+        description:
+            'Print coverage of the Hull Heads shark fatality quoting Jodie Rummer on shark behaviour, shark-human interactions, and evidence-based management.',
+        url: '',
         date: '2026-05-26',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Townsville Bulletin",
-        title: "Cairns man identified as shark attack victim",
-        description: "Print coverage of the Kennedy Shoal shark fatality quoting Jodie Rummer on bull sharks, seasonal shark activity, and evidence-based shark management.",
-        url: "",
+        source: 'Townsville Bulletin',
+        title: 'Cairns man identified as shark attack victim',
+        description:
+            'Print coverage of the Kennedy Shoal shark fatality quoting Jodie Rummer on bull sharks, seasonal shark activity, and evidence-based shark management.',
+        url: '',
         date: '2026-05-26',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Discover Wildlife",
-        title: "Walking sharks found off Australian coast",
-        description: "\"Walking sharks\" found off Australian coast. A closer look reveals extraordinary new discovery about epaulette shark reproduction.",
-        url: "https://www.discoverwildlife.com/animal-facts/marine-animals/epaulette-shark-reproduction",
+        source: 'Discover Wildlife',
+        title: 'Walking sharks found off Australian coast',
+        description:
+            '"Walking sharks" found off Australian coast. A closer look reveals extraordinary new discovery about epaulette shark reproduction.',
+        url: 'https://www.discoverwildlife.com/animal-facts/marine-animals/epaulette-shark-reproduction',
         date: '2026-01-15',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "ABC News",
-        title: "Captive epaulette sharks lay eggs using no extra energy, JCU research finds",
-        description: "Captive epaulette sharks lay eggs using no extra energy, JCU research finds",
-        url: "https://www.abc.net.au/news/2026-01-16/captive-epaulette-sharks-make-lay-eggs-using-no-extra-energy-jcu/106231990",
+        source: 'ABC News',
+        title: 'Captive epaulette sharks lay eggs using no extra energy, JCU research finds',
+        description:
+            'Captive epaulette sharks lay eggs using no extra energy, JCU research finds',
+        url: 'https://www.abc.net.au/news/2026-01-16/captive-epaulette-sharks-make-lay-eggs-using-no-extra-energy-jcu/106231990',
         date: '2026-01-16',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'article',
-        source: "ABC News",
-        title: "Epaulette sharks are breaking the rules of biology",
-        description: "Epaulette sharks are breaking the rules of biology",
-        url: "https://www.abc.net.au/news/2026-01-16/epaulette-sharks-are-breaking-the-rules-of-biology/106229708",
+        source: 'ABC News',
+        title: 'Epaulette sharks are breaking the rules of biology',
+        description: 'Epaulette sharks are breaking the rules of biology',
+        url: 'https://www.abc.net.au/news/2026-01-16/epaulette-sharks-are-breaking-the-rules-of-biology/106229708',
         date: '2026-01-16',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'article',
-        source: "The Conversation",
+        source: 'The Conversation',
         title: "Sharks freeze when you turn them upside down – and there's no good reason why",
-        description: "Research explores tonic immobility in sharks, rays and their relatives.",
-        url: "https://theconversation.com/sharks-freeze-when-you-turn-them-upside-down-and-theres-no-good-reason-why-259448",
+        description:
+            'Research explores tonic immobility in sharks, rays and their relatives.',
+        url: 'https://theconversation.com/sharks-freeze-when-you-turn-them-upside-down-and-theres-no-good-reason-why-259448',
         date: '2025-06-23',
-        sourceType: 'The Conversation'
+        sourceType: 'The Conversation',
     },
     {
         type: 'article',
-        source: "The Guardian",
-        title: "Shark attacks in Australia: where is it safest to swim and what times should I avoid?",
-        description: "While the overall risk of a shark attack remains low, experts say warmer waters, various weather events, shifting prey and busier coastlines can increase the risk",
-        url: "https://www.theguardian.com/australia-news/2026/feb/05/shark-attacks-in-australia-where-is-it-safest-to-swim-and-what-times-should-i-avoid",
+        source: 'The Guardian',
+        title: 'Shark attacks in Australia: where is it safest to swim and what times should I avoid?',
+        description:
+            'While the overall risk of a shark attack remains low, experts say warmer waters, various weather events, shifting prey and busier coastlines can increase the risk',
+        url: 'https://www.theguardian.com/australia-news/2026/feb/05/shark-attacks-in-australia-where-is-it-safest-to-swim-and-what-times-should-i-avoid',
         date: '2026-02-05',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
+        source: 'The Guardian',
         title: "After four shark attacks in 48 hours, NSW authorities urge beachgoers 'just go to a pool'",
-        description: "Surfer taken to hospital with minor injuries after latest shark attack at Point Plomer beach on mid-north coast",
-        url: "https://www.theguardian.com/australia-news/2026/jan/20/shark-attack-nsw-coast-fourth-incident-man-surfer",
+        description:
+            'Surfer taken to hospital with minor injuries after latest shark attack at Point Plomer beach on mid-north coast',
+        url: 'https://www.theguardian.com/australia-news/2026/jan/20/shark-attack-nsw-coast-fourth-incident-man-surfer',
         date: '2026-01-20',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
+        source: 'The Guardian',
         title: "Marine wildlife fleeing to poles due to global heating as Australian oceans face 'uncharted' future",
-        description: "From 2040 onwards the average year for marine ecosystems is likely to be more extreme than the worst years experienced up until 2015, researchers say",
-        url: "https://www.theguardian.com/environment/2025/oct/29/climate-change-global-heating-warming-oceans-uncharted-future-australia",
+        description:
+            'From 2040 onwards the average year for marine ecosystems is likely to be more extreme than the worst years experienced up until 2015, researchers say',
+        url: 'https://www.theguardian.com/environment/2025/oct/29/climate-change-global-heating-warming-oceans-uncharted-future-australia',
         date: '2025-10-29',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "Oceanographic Magazine",
-        title: "Epaulette shark research in Oceanographic Magazine",
-        description: "Feature coverage of RummerLab epaulette shark research highlighting the team's long-running work on climate change, reef sharks, and accessible ocean science.",
-        url: "https://oceanographicmagazine.com/",
+        source: 'Oceanographic Magazine',
+        title: 'Epaulette shark research in Oceanographic Magazine',
+        description:
+            "Feature coverage of RummerLab epaulette shark research highlighting the team's long-running work on climate change, reef sharks, and accessible ocean science.",
+        url: 'https://oceanographicmagazine.com/',
         date: '2021-10-22',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Oceanographic Magazine",
-        title: "Jodie Rummer: For the love of sharks",
-        description: "Oceanographic Magazine feature on Jodie Rummer and her work with sharks, climate change, reef sharks, and accessible ocean science.",
-        url: "https://oceanographicmagazine.com/features/jodie-rummer-for-the-love-of-sharks/",
+        source: 'Oceanographic Magazine',
+        title: 'Jodie Rummer: For the love of sharks',
+        description:
+            'Oceanographic Magazine feature on Jodie Rummer and her work with sharks, climate change, reef sharks, and accessible ocean science.',
+        url: 'https://oceanographicmagazine.com/features/jodie-rummer-for-the-love-of-sharks/',
         date: '2025-03-03',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "The Guardian",
-        title: "Pencils with teeth: meet the tiny cookiecutter shark that attacked a catamaran off Cairns",
-        description: "These parasitic sharks glow in the dark and are known to have a go at anything they come across, despite their small size",
-        url: "https://www.theguardian.com/environment/2023/sep/07/cookiecutter-sharks-what-are-cairns-catamaran-attack",
+        source: 'The Guardian',
+        title: 'Pencils with teeth: meet the tiny cookiecutter shark that attacked a catamaran off Cairns',
+        description:
+            'These parasitic sharks glow in the dark and are known to have a go at anything they come across, despite their small size',
+        url: 'https://www.theguardian.com/environment/2023/sep/07/cookiecutter-sharks-what-are-cairns-catamaran-attack',
         date: '2023-09-07',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'interview',
-        source: "WGBH",
-        title: "Dr. Jodie Rummer - WGBH",
-        description: "WGBH coverage featuring Dr. Jodie Rummer.",
-        url: "https://www.wgbh.org/people/dr-jodie-rummer",
+        source: 'WGBH',
+        title: 'Dr. Jodie Rummer - WGBH',
+        description: 'WGBH coverage featuring Dr. Jodie Rummer.',
+        url: 'https://www.wgbh.org/people/dr-jodie-rummer',
         date: '2023-08-14',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "The Guardian",
-        title: "Marine heatwave off north-east Australia sets off alarm over health of Great Barrier Reef",
-        description: "Experts fear for health of corals and other marine life as about 1m sq km of ocean experience prolonged elevated temperatures",
-        url: "https://www.theguardian.com/environment/2023/jul/22/marine-heatwave-in-north-east-queensland-sets-off-alarm-over-health-of-great-barrier-reef",
+        source: 'The Guardian',
+        title: 'Marine heatwave off north-east Australia sets off alarm over health of Great Barrier Reef',
+        description:
+            'Experts fear for health of corals and other marine life as about 1m sq km of ocean experience prolonged elevated temperatures',
+        url: 'https://www.theguardian.com/environment/2023/jul/22/marine-heatwave-in-north-east-queensland-sets-off-alarm-over-health-of-great-barrier-reef',
         date: '2023-07-22',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
+        source: 'The Guardian',
         title: "'Extinction crisis' of sharks and rays to have devastating effect on other species, study finds",
-        description: "Almost two-thirds of sharks and rays living on world's coral reefs at risk, with 14 of 134 species reviewed critically endangered",
-        url: "https://www.theguardian.com/environment/2023/jan/18/extinction-crisis-of-sharks-and-rays-to-have-devastating-effect-on-other-species-study-finds",
+        description:
+            "Almost two-thirds of sharks and rays living on world's coral reefs at risk, with 14 of 134 species reviewed critically endangered",
+        url: 'https://www.theguardian.com/environment/2023/jan/18/extinction-crisis-of-sharks-and-rays-to-have-devastating-effect-on-other-species-study-finds',
         date: '2023-01-18',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
-        title: "Great Barrier Reef on verge of another mass bleaching after highest temperatures on record",
-        description: "'Shocked and concerned' US government scientists say heat stress over Australia's ocean jewel is unprecedented",
-        url: "https://www.theguardian.com/environment/2022/jan/29/great-barrier-reef-on-verge-of-another-mass-bleaching-after-highest-temperatures-on-record",
+        source: 'The Guardian',
+        title: 'Great Barrier Reef on verge of another mass bleaching after highest temperatures on record',
+        description:
+            "'Shocked and concerned' US government scientists say heat stress over Australia's ocean jewel is unprecedented",
+        url: 'https://www.theguardian.com/environment/2022/jan/29/great-barrier-reef-on-verge-of-another-mass-bleaching-after-highest-temperatures-on-record',
         date: '2022-01-29',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
+        source: 'The Guardian',
         title: "Marine species increasingly can't live at equator due to global heating",
-        description: "Study suggests it is already too warm in tropics for some species to survive",
-        url: "https://www.theguardian.com/environment/2021/apr/08/marine-species-increasingly-cant-live-at-equator-due-to-global-heating",
+        description:
+            'Study suggests it is already too warm in tropics for some species to survive',
+        url: 'https://www.theguardian.com/environment/2021/apr/08/marine-species-increasingly-cant-live-at-equator-due-to-global-heating',
         date: '2021-04-08',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
+        source: 'The Guardian',
         title: "Will sharks survive? Scientists fear for ocean's apex predators without more protection",
-        description: "Australia's spike in shark deaths bears no correlation to how they are doing globally due to overfishing, scientists say",
-        url: "https://www.theguardian.com/environment/2021/jan/31/will-sharks-survive-scientists-fear-for-oceans-apex-predators-without-more-protection",
+        description:
+            "Australia's spike in shark deaths bears no correlation to how they are doing globally due to overfishing, scientists say",
+        url: 'https://www.theguardian.com/environment/2021/jan/31/will-sharks-survive-scientists-fear-for-oceans-apex-predators-without-more-protection',
         date: '2021-01-31',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "The Guardian",
-        title: "Baby sharks emerge from egg cases earlier and weaker in oceans warmed by climate crisis",
-        description: "Weaker sharks are less effective hunters, which can upset the balance of the ecosystem, say authors of study into impacts of hotter oceans",
-        url: "https://www.theguardian.com/environment/2021/jan/12/baby-sharks-emerge-from-egg-cases-earlier-and-weaker-in-oceans-warmed-by-climate-crisis",
+        source: 'The Guardian',
+        title: 'Baby sharks emerge from egg cases earlier and weaker in oceans warmed by climate crisis',
+        description:
+            'Weaker sharks are less effective hunters, which can upset the balance of the ecosystem, say authors of study into impacts of hotter oceans',
+        url: 'https://www.theguardian.com/environment/2021/jan/12/baby-sharks-emerge-from-egg-cases-earlier-and-weaker-in-oceans-warmed-by-climate-crisis',
         date: '2021-01-12',
-        sourceType: 'The Guardian'
+        sourceType: 'The Guardian',
     },
     {
         type: 'article',
-        source: "Sydney Morning Herald",
+        source: 'Sydney Morning Herald',
         title: "Shark researcher Jodie Rummer wins UNESCO L'Oreal For Women in Science fellowship",
-        description: "Shark researcher Jodie Rummer wins UNESCO L'Oreal For Women in Science fellowship.",
-        url: "https://www.smh.com.au/technology/shark-researcher-jodie-rummer-wins-unesco-loreal-for-women-in-science-fellowship-20150907-gjgpcz.html",
+        description:
+            "Shark researcher Jodie Rummer wins UNESCO L'Oreal For Women in Science fellowship.",
+        url: 'https://www.smh.com.au/technology/shark-researcher-jodie-rummer-wins-unesco-loreal-for-women-in-science-fellowship-20150907-gjgpcz.html',
         date: '2015-09-08',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Sydney Morning Herald",
+        source: 'Sydney Morning Herald',
         title: "Science trails the tales of city's bull sharks",
-        description: "Syndicated coverage quoting Jodie Rummer on warming waters, bull shark movements, and the importance of healthy shark populations in healthy marine ecosystems.",
-        url: "https://www.smh.com.au/politics/nsw/shark-diaries-where-did-lucy-bruce-and-paulie-the-bull-sharks-go-this-week-20240131-p5f19y.html",
+        description:
+            'Syndicated coverage quoting Jodie Rummer on warming waters, bull shark movements, and the importance of healthy shark populations in healthy marine ecosystems.',
+        url: 'https://www.smh.com.au/politics/nsw/shark-diaries-where-did-lucy-bruce-and-paulie-the-bull-sharks-go-this-week-20240131-p5f19y.html',
         date: '2024-02-01',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "Brisbane Times / SMH / The Age / WA Today",
-        title: "Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?",
-        description: "Online syndicated coverage quoting Jodie Rummer on bull shark migration, warm Sydney waters, and shark conservation.",
-        url: "https://www.smh.com.au/politics/nsw/shark-diaries-where-did-lucy-bruce-and-paulie-the-bull-sharks-go-this-week-20240131-p5f19y.html",
+        source: 'Brisbane Times / SMH / The Age / WA Today',
+        title: 'Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?',
+        description:
+            'Online syndicated coverage quoting Jodie Rummer on bull shark migration, warm Sydney waters, and shark conservation.',
+        url: 'https://www.smh.com.au/politics/nsw/shark-diaries-where-did-lucy-bruce-and-paulie-the-bull-sharks-go-this-week-20240131-p5f19y.html',
         date: '2024-01-31',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'interview',
-        source: "ABC Radio Queensland",
-        title: "Professor Jodie Rummer on Cyclone Kirrily and reef climate impacts",
-        description: "ABC Radio Queensland interview discussing Cyclone Kirrily, climate impacts, and the Great Barrier Reef.",
-        url: "https://www.youtube.com/watch?v=G0Khf32LHEQ",
+        source: 'ABC Radio Queensland',
+        title: 'Professor Jodie Rummer on Cyclone Kirrily and reef climate impacts',
+        description:
+            'ABC Radio Queensland interview discussing Cyclone Kirrily, climate impacts, and the Great Barrier Reef.',
+        url: 'https://www.youtube.com/watch?v=G0Khf32LHEQ',
         date: '2024-01-31',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'interview',
-        source: "WIN News",
-        title: "Coral reefs and conference coverage featuring Dr Jodie Rummer",
-        description: "Regional WIN News coverage from the Australian Coral Reef Society conference in Townsville, featuring Jodie Rummer as ACRS President on coral reefs and climate action.",
-        url: "",
+        source: 'WIN News',
+        title: 'Coral reefs and conference coverage featuring Dr Jodie Rummer',
+        description:
+            'Regional WIN News coverage from the Australian Coral Reef Society conference in Townsville, featuring Jodie Rummer as ACRS President on coral reefs and climate action.',
+        url: '',
         date: '2025-09-17',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'interview',
-        source: "ABC Radio Queensland",
-        title: "Professor Jodie Rummer on ocean warming and the Great Barrier Reef",
-        description: "ABC Queensland statewide radio interview giving the Copernicus report a Queensland perspective, with a focus on oceans, the Reef, emissions cuts, and the limits of adaptation alone.",
-        url: "",
+        source: 'ABC Radio Queensland',
+        title: 'Professor Jodie Rummer on ocean warming and the Great Barrier Reef',
+        description:
+            'ABC Queensland statewide radio interview giving the Copernicus report a Queensland perspective, with a focus on oceans, the Reef, emissions cuts, and the limits of adaptation alone.',
+        url: '',
         date: '2026-01-15',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'interview',
-        source: "ABC Radio Queensland",
-        title: "Dr Jodie Rummer warns shark culling will not address risks",
-        description: "ABC radio coverage after the fatal Kennedy Shoal shark incident, quoting Jodie Rummer on using science to protect people and sharks rather than relying on culling.",
-        url: "",
+        source: 'ABC Radio Queensland',
+        title: 'Dr Jodie Rummer warns shark culling will not address risks',
+        description:
+            'ABC radio coverage after the fatal Kennedy Shoal shark incident, quoting Jodie Rummer on using science to protect people and sharks rather than relying on culling.',
+        url: '',
         date: '2026-05-26',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'interview',
-        source: "ABC Far North",
-        title: "Dr Jodie Rummer discusses shark populations and culling on Breakfast",
-        description: "ABC Far North Breakfast interview discussing shark population complexity, depleted shark populations, human-shark interactions, and why culling does not address the underlying risks.",
-        url: "",
+        source: 'ABC Far North',
+        title: 'Dr Jodie Rummer discusses shark populations and culling on Breakfast',
+        description:
+            'ABC Far North Breakfast interview discussing shark population complexity, depleted shark populations, human-shark interactions, and why culling does not address the underlying risks.',
+        url: '',
         date: '2026-05-26',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
+        sources: [
+            { name: 'ABC North Queensland' },
+            { name: 'ABC Tropical North' },
+            { name: 'ABC Gold Coast' },
+        ],
     },
     {
         type: 'article',
-        source: "ABC News",
-        title: "Shark cull will not improve beach safety or reduce attacks, marine biologists say",
-        description: "James Cook University professor of marine biology Jodie Rummer said there was \"no scientific evidence that culling programs work to remove problematic animals\" after the Coogee Beach shark attack. \"It's not that there are more sharks in the water, it's just that they're in different places at different times than they have [been] historically,\" she said.",
-        url: "https://www.abc.net.au/news/2026-06-16/shark-cull-wont-fix-sydney-beach-safety-marine-biologists-say/106797826",
+        source: 'ABC News',
+        title: 'Shark cull will not improve beach safety or reduce attacks, marine biologists say',
+        description:
+            'James Cook University professor of marine biology Jodie Rummer said there was "no scientific evidence that culling programs work to remove problematic animals" after the Coogee Beach shark attack. "It\'s not that there are more sharks in the water, it\'s just that they\'re in different places at different times than they have [been] historically," she said.',
+        url: 'https://www.abc.net.au/news/2026-06-16/shark-cull-wont-fix-sydney-beach-safety-marine-biologists-say/106797826',
         date: '2026-06-16',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
+        sources: [
+            {
+                name: 'RNZ',
+                url: 'https://www.rnz.co.nz/news/world/598308/shark-cull-will-not-improve-beach-safety-or-reduce-attacks-marine-biologists-say',
+            },
+        ],
     },
     {
         type: 'article',
-        source: "Nature",
-        title: "Oceans in Asia smash heat records — what it means for extreme weather",
-        description: "Almost all of Asia's oceans experienced marine heatwaves at the same time in 2025, which Jodie Rummer, a marine biologist at James Cook University, said is alarming because so much of the region was affected simultaneously.",
-        url: "https://www.nature.com/articles/d41586-026-01938-2",
+        source: 'Nature',
+        title: 'Oceans in Asia smash heat records — what it means for extreme weather',
+        description:
+            "Almost all of Asia's oceans experienced marine heatwaves at the same time in 2025, which Jodie Rummer, a marine biologist at James Cook University, said is alarming because so much of the region was affected simultaneously.",
+        url: 'https://www.nature.com/articles/d41586-026-01938-2',
         date: '2026-06-18',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'interview',
-        source: "ABC Radio",
-        title: "Shark deterrent surfboard fin in development",
-        description: "ABC PM segment on a University of Wollongong surfboard fin with embedded shark-deterrent technology, featuring Dr Jodie Rummer, Professor of Marine Biology at James Cook University.",
-        url: "https://www.abc.net.au/listen/programs/pm/shark-deterrent-surfboard-fin-in-development-/106569176",
+        source: 'ABC Radio',
+        title: 'Shark deterrent surfboard fin in development',
+        description:
+            'ABC PM segment on a University of Wollongong surfboard fin with embedded shark-deterrent technology, featuring Dr Jodie Rummer, Professor of Marine Biology at James Cook University.',
+        url: 'https://www.abc.net.au/listen/programs/pm/shark-deterrent-surfboard-fin-in-development-/106569176',
         date: '2026-04-15',
-        sourceType: 'ABC News'
+        sourceType: 'ABC News',
     },
     {
         type: 'article',
-        source: "Cosmos Magazine",
-        title: "Childhood dreams of breathing underwater inspired fish physiology career",
-        description: "A gift of snorkelling gear and a trip to Florida was all it took to hook 8-year-old Jodie Rummer into marine science. \"Wow, that was it for me!\" recalls Rummer, now Professor of Marine Science at James Cook University.",
-        url: "https://cosmosmagazine.com/nature/marine-life/jodie-rummer-fish-physiology/",
+        source: 'Cosmos Magazine',
+        title: 'Childhood dreams of breathing underwater inspired fish physiology career',
+        description:
+            'A gift of snorkelling gear and a trip to Florida was all it took to hook 8-year-old Jodie Rummer into marine science. "Wow, that was it for me!" recalls Rummer, now Professor of Marine Science at James Cook University.',
+        url: 'https://cosmosmagazine.com/nature/marine-life/jodie-rummer-fish-physiology/',
         date: '2025-08-17',
-        sourceType: 'Other'
+        sourceType: 'Other',
     },
     {
         type: 'article',
-        source: "news.com.au",
-        title: "Shark culling protects politicians more than people, experts say as calls for a cull reignite",
-        description: "James Cook University professor of marine biology Jodie Rummer said, \"I think that we've had enough lessons in all of science and all of biology that show us that when we remove predators from an ecosystem then it disrupts the whole ecosystem … and it takes us decades, if not a century, to fix it.\"",
-        url: "https://www.news.com.au/technology/science/animals/shark-culling-protects-politicians-more-than-people-experts-say-as-calls-for-a-cull-reignite/news-story/a584820c799b4c99326bed1ab69c9741",
+        source: 'news.com.au',
+        title: 'Shark culling protects politicians more than people, experts say as calls for a cull reignite',
+        description:
+            'James Cook University professor of marine biology Jodie Rummer said, "I think that we\'ve had enough lessons in all of science and all of biology that show us that when we remove predators from an ecosystem then it disrupts the whole ecosystem … and it takes us decades, if not a century, to fix it."',
+        url: 'https://www.news.com.au/technology/science/animals/shark-culling-protects-politicians-more-than-people-experts-say-as-calls-for-a-cull-reignite/news-story/a584820c799b4c99326bed1ab69c9741',
         date: '2026-06-21',
-        sourceType: 'Other'
+        sourceType: 'Other',
+        sources: newsCorpCullSyndicates,
     },
     {
         type: 'article',
-        source: "RNZ",
-        title: "Shark cull will not improve beach safety or reduce attacks, marine biologists say",
-        description: "James Cook University professor of marine biology Jodie Rummer said there was \"no scientific evidence that culling programs work to remove problematic animals\" and that sharks are \"in different places at different times than they have [been] historically.\"",
-        url: "https://www.rnz.co.nz/news/world/598308/shark-cull-will-not-improve-beach-safety-or-reduce-attacks-marine-biologists-say",
-        date: '2026-06-16',
-        sourceType: 'Other'
-    },
-    {
-        type: 'article',
-        source: "Popular Mechanics",
+        source: 'Popular Mechanics',
         title: "Scientists Found a Creature That's Breaking the Rules of Reproduction",
-        description: "\"Reproduction is the ultimate investment … you are literally building new life from scratch,\" Jodie Rummer, senior author of the James Cook University walking-shark study, said. \"We expected that when sharks make this complex egg, their energy use would shoot up.\" There was no uptick: \"it was completely flat.\"",
-        url: "https://www.popularmechanics.com/science/animals/a70081203/walking-shark-reproduction/",
+        description:
+            '"Reproduction is the ultimate investment … you are literally building new life from scratch," Jodie Rummer, senior author of the James Cook University walking-shark study, said. "We expected that when sharks make this complex egg, their energy use would shoot up." There was no uptick: "it was completely flat."',
+        url: 'https://www.popularmechanics.com/science/animals/a70081203/walking-shark-reproduction/',
         date: '2026-01-27',
-        sourceType: 'Other'
+        sourceType: 'Other',
+        sources: [
+            {
+                name: 'Forbes',
+                title: 'Walking Sharks Rewrite The Rules Of Reproduction',
+            },
+        ],
     },
     {
         type: 'article',
-        source: "Frontiers in Fish Science",
-        title: "Inclusive science for a changing ocean: Gender equity in elasmobranch research",
-        description: "A Perspective co-authored by Jodie L. Rummer arguing that gender equity and diverse leadership are essential to the intellectual robustness of shark and ray science, not optional extras.",
-        url: "https://www.frontiersin.org/journals/fish-science/articles/10.3389/frish.2026.1816786/full",
+        source: 'Frontiers in Fish Science',
+        title: 'Inclusive science for a changing ocean: Gender equity in elasmobranch research',
+        description:
+            'A Perspective co-authored by Jodie L. Rummer arguing that gender equity and diverse leadership are essential to the intellectual robustness of shark and ray science, not optional extras.',
+        url: 'https://www.frontiersin.org/journals/fish-science/articles/10.3389/frish.2026.1816786/full',
         date: '2026-06-23',
-        sourceType: 'Research Highlight'
-    }
-];
+        sourceType: 'Research Highlight',
+    },
+    {
+        type: 'interview',
+        source: 'WIN News',
+        title: 'Scientists warn broad shark culling will not improve safety after WA spearfishing death',
+        description:
+            'WIN News listed Jodie Rummer among interviewees after a fatal WA shark attack, with the bulletin stating the evidence does not show that broad culling programmes reliably improve human safety.',
+        date: '2026-06-08',
+        sourceType: 'Other',
+        sources: [
+            { name: 'WIN News Central Queensland' },
+            { name: 'WIN News Darling Downs' },
+        ],
+    },
+    {
+        type: 'podcast',
+        source: 'FINcast',
+        title: 'Baby shark research in French Polynesia | Prof. Jodie Rummer',
+        description:
+            'Jodie Rummer discusses Physioshark newborn-shark research in French Polynesia on the FINcast shark-conservation podcast.',
+        url: 'https://open.spotify.com/episode/68PWxjmxwxTTfaLzCrzOPI',
+        date: '2026-06-15',
+        sourceType: 'Science Podcast',
+    },
+]
 
 const sortMediaByDateDesc = (items: MediaItem[]): MediaItem[] => {
     return [...items].sort(
-        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-    );
-};
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    )
+}
 
 export const getSortedMediaItems = (): MediaItem[] => {
-    return sortMediaByDateDesc(mediaItems);
-};
+    return sortMediaByDateDesc(mediaItems)
+}
 
 export const getMediaByType = (type: MediaItem['type']) => {
-    return mediaItems.filter((item) => item.type === type);
-};
+    return mediaItems.filter((item) => item.type === type)
+}
 
 export const getFeaturedMedia = (count: number = 3) => {
-    return getSortedMediaItems().slice(0, count);
-};
+    return getSortedMediaItems().slice(0, count)
+}
 
 export type MediaPage = {
-    total: number;
-    limit: number;
-    offset: number;
-    media: MediaItem[];
-};
+    total: number
+    limit: number
+    offset: number
+    media: MediaItem[]
+}
 
 export const getMediaPage = (params: {
-    limit?: number;
-    offset?: number;
+    limit?: number
+    offset?: number
 }): MediaPage => {
-    const limit = Math.max(0, params.limit ?? 100);
-    const offset = Math.max(0, params.offset ?? 0);
-    const sorted = getSortedMediaItems();
+    const limit = Math.max(0, params.limit ?? 100)
+    const offset = Math.max(0, params.offset ?? 0)
+    const sorted = getSortedMediaItems()
 
     return {
         total: sorted.length,
         limit,
         offset,
         media: sorted.slice(offset, offset + limit),
-    };
-};
+    }
+}

--- a/types/media.ts
+++ b/types/media.ts
@@ -1,16 +1,44 @@
+export type MediaSourceType =
+    | 'The Conversation'
+    | 'ABC News'
+    | 'CNN'
+    | 'Science Podcast'
+    | 'Research Highlight'
+    | 'The Guardian'
+    | 'Other';
+
+export interface MediaSource {
+    name: string;
+    url?: string;
+    sourceType?: MediaSourceType;
+    title?: string;
+}
+
 export interface MediaItem {
     type: 'article' | 'interview' | 'podcast' | 'press';
     source: string;
     title: string;
     description: string;
-    url: string;
+    url?: string;
     date: string;
-    sourceType: 'The Conversation' | 'ABC News' | 'CNN' | 'Science Podcast' | 'Research Highlight' | 'The Guardian' | 'Other';
+    sourceType: MediaSourceType;
+    sources?: MediaSource[];
     image?: {
         url: string;
         alt: string;
     };
 }
+
+export const getMediaSources = (item: MediaItem): MediaSource[] => {
+    const primary: MediaSource = {
+        name: item.source,
+        url: item.url,
+        sourceType: item.sourceType,
+        title: item.title,
+    };
+
+    return [primary, ...(item.sources ?? [])];
+};
 
 export interface RSSItem {
     title?: string;
@@ -28,4 +56,4 @@ export interface RSSItem {
             type: string;
         };
     };
-} 
+}


### PR DESCRIPTION
## Summary
- Add three new `MediaItem` entries from the athletesofthereef Inbox catch-up: ABC News on the June 2026 Sydney shark-cull debate (Jodie quoted), Nature on Asia marine heatwaves (Jodie quoted), and the 15 April 2026 ABC PM shark-deterrent interview.
- Skip syndicated copies, grant/funding Google Alerts, Scholar-only mail, and sensational shark-attack clips that do not quote Jodie or the lab.
- JCU summary PDFs could not be decoded via Gmail (metadata only), so those threads stay in Inbox.

## Test plan
- [ ] Confirm https://rummerlab.com/media lists the three new items after merge
- [ ] Open each URL and check it is public (no MediaPortal/Isentia/session links)
- [ ] Spot-check that existing May 2026 Hull Heads / walking-shark items were not duplicated

Made with [Cursor](https://cursor.com)