### PR TITLE
Add RummerLab blog and FINcast French Polynesia post

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ Stack: Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS 4. Config is 
 
 ## Project overview
 
-Marine biology lab site for Professor Jodie Rummer at James Cook University: research, team, publications, media, podcast, gallery, and Physioshark.
+Marine biology lab site for Professor Jodie Rummer at James Cook University: research, team, publications, media, podcast, blog, gallery, and Physioshark.
+
+Podcast episodes live in `_podcast-episodes/` and render at `/podcast` and `/podcast/[slug]`. Lab blog posts live in `_blog/` and render at `/blog` and `/blog/[slug]`.
 
 Sister sites: [jodierummer.com](https://jodierummer.com), [physioshark.org](https://physioshark.org). Spell **RummerLab** with no space.
 

--- a/_blog/fincast-baby-shark-research-french-polynesia.md
+++ b/_blog/fincast-baby-shark-research-french-polynesia.md
@@ -1,0 +1,44 @@
+---
+date: "2026-06-15T18:43:00+10:00"
+coverImage: "/images/podcast/debaere-et-al-2025-j-fish-biology/blacktip-reef-shark-belly-button.jpg"
+coverImageAlt: "Neonatal blacktip reef shark belly showing an umbilical scar from Physioshark fieldwork"
+title: "Baby shark research in French Polynesia, on FINcast"
+excerpt: "Professor Jodie Rummer joined FINcast | Shark Conservation to talk about newborn reef sharks in French Polynesia — the Physioshark work RummerLab does on Mo'orea with science4reefs."
+podcast: "FINcast | Shark Conservation"
+spotify: "https://open.spotify.com/episode/68PWxjmxwxTTfaLzCrzOPI"
+gallery:
+  - src: "/images/podcast/debaere-et-al-2025-j-fish-biology/blacktip-reef-shark-belly-button.jpg"
+    alt: "Blacktip reef shark belly with healed umbilical scar"
+    caption: "Neonatal blacktip reef shark, Physioshark fieldwork"
+    credit: "Photo: Laura Boderke on behalf of Physioshark"
+  - src: "/images/podcast/debaere-et-al-2025-j-fish-biology/blacktip-reef-shark-belly-button-measurement.jpg"
+    alt: "Researcher measuring the umbilical scar on a neonatal blacktip reef shark"
+    caption: "Measuring an umbilical scar on a newborn blacktip reef shark"
+    credit: "Photo: Laura Boderke on behalf of Physioshark"
+---
+
+On 15 June 2026, Professor Jodie Rummer appeared on *[FINcast | Shark Conservation](https://open.spotify.com/episode/68PWxjmxwxTTfaLzCrzOPI)* for the episode **Baby shark research In French Polynesia | Prof. Jodie Rummer**.
+
+The episode listing puts it plainly: Jodie discusses newborn-shark research taking place in French Polynesia. FINcast bills that work as the “Mama Shark Project.” On this site we call it **[Physioshark](/physioshark-project)** — RummerLab’s long-running conservation-physiology programme on shark nurseries.
+
+## Why French Polynesia
+
+Physioshark fieldwork is on Mo'orea, French Polynesia, with [science4reefs](https://www.science4reefs-cnrs.com/). Mother sharks give birth to blacktip reef sharks (*Carcharhinus melanopterus*) and sicklefin lemon sharks (*Negaprion acutidens*) each austral summer. Those shallow nurseries are where the team can study how newborns cope now, and how they may cope as oceans warm.
+
+French Polynesia is also one of the world’s largest shark sanctuaries, which makes it possible to do this work without a lethal shark-control programme in the background.
+
+## What the lab actually measures
+
+Newborn reef sharks arrive with no parental care, high predation risk, and — for a short time — an open umbilical wound. RummerLab and collaborators have been quantifying how those pups heal, grow, and perform in the heat and low oxygen of a changing reef.
+
+That physiology is the through-line of Physioshark: not just “are there still sharks here?” but “can these athletes of the reef keep performing as the habitat shifts?”
+
+If you want the peer-reviewed version of the baby-shark healing story, start with Debaere and colleagues in the *Journal of Fish Biology*, and with [Episode 2 of Athletes of the Reef](/podcast/debaere-et-al-2025-j-fish-biology).
+
+## Listen
+
+The FINcast conversation is about 23 minutes.
+
+- [Listen on Spotify](https://open.spotify.com/episode/68PWxjmxwxTTfaLzCrzOPI)
+- [Physioshark Project](/physioshark-project)
+- [Athletes of the Reef podcast](/podcast)

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,173 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import { getAllSiteBlogSlugs, getSiteBlogPostBySlug } from '@/lib/site-blog';
+import BlogGallery from '@/components/BlogGallery';
+import { sanitizeSlugForUrl } from '@/lib/utils';
+import { sanitizeHtml } from '@/lib/sanitize';
+
+interface BlogPostPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  const slugs = getAllSiteBlogSlugs();
+  return slugs.map((slug) => ({
+    slug,
+  }));
+}
+
+export async function generateMetadata({
+  params,
+}: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getSiteBlogPostBySlug(slug);
+
+  if (!post) {
+    return {
+      title: 'Post Not Found | RummerLab',
+    };
+  }
+
+  const title = `${post.title} | RummerLab`;
+  const description = post.excerpt || post.content.substring(0, 160);
+  const url = `https://rummerlab.com/blog/${sanitizeSlugForUrl(slug)}`;
+  const coverImageUrl = post.coverImage
+    ? `https://rummerlab.com${post.coverImage}`
+    : 'https://rummerlab.com/images/rummerlab_logo_transparent.png';
+  const coverImageAlt = post.coverImageAlt || post.title;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'RummerLab',
+      images: [
+        {
+          url: coverImageUrl,
+          width: 1200,
+          height: 630,
+          alt: coverImageAlt,
+        },
+      ],
+      locale: 'en_US',
+      type: 'article',
+      publishedTime: post.date,
+      authors: ['RummerLab'],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [coverImageUrl],
+      creator: '@rummerlab',
+      site: '@rummerlab',
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
+    },
+  };
+}
+
+const formatDate = (dateString: string): string => {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  } catch {
+    return dateString;
+  }
+};
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params;
+  const post = getSiteBlogPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <Link
+        href="/blog"
+        className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:underline mb-8"
+      >
+        ← Back to RummerLab blog
+      </Link>
+
+      <header className="mb-8">
+        <time
+          className="text-sm text-gray-500 dark:text-gray-400 block mb-4"
+          dateTime={post.date}
+        >
+          {formatDate(post.date)}
+        </time>
+
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+          {post.title}
+        </h1>
+
+        {post.podcast && (
+          <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
+            Featured on: {post.podcast}
+          </p>
+        )}
+
+        {post.coverImage && (
+          <div className="mb-6 rounded-lg overflow-hidden">
+            <Image
+              src={post.coverImage}
+              alt={post.coverImageAlt || post.title}
+              width={1200}
+              height={630}
+              className="w-full h-auto object-cover"
+              priority
+            />
+          </div>
+        )}
+
+        {post.spotify && (
+          <div className="flex flex-wrap gap-3 mb-6">
+            <a
+              href={post.spotify}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2.5 px-5 py-3 bg-cyan-600 text-white rounded-lg hover:bg-cyan-700 dark:bg-cyan-500 dark:hover:bg-cyan-600 transition-all duration-200 shadow-md hover:shadow-lg hover:shadow-cyan-500/30 transform hover:-translate-y-0.5 focus:outline-hidden focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 font-medium"
+            >
+              <span className="text-lg" aria-hidden="true">🎧</span>
+              <span>Listen on Spotify</span>
+            </a>
+          </div>
+        )}
+      </header>
+
+      <article
+        className="prose prose-lg prose-gray dark:prose-invert max-w-none"
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(post.htmlContent) }}
+      />
+
+      {post.gallery && post.gallery.length > 0 && (
+        <BlogGallery images={post.gallery} />
+      )}
+    </div>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,124 @@
+import { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { getAllSiteBlogPosts } from '@/lib/site-blog';
+import { sanitizeSlugForUrl } from '@/lib/utils';
+
+export const metadata: Metadata = {
+  title: 'Blog | RummerLab',
+  description:
+    'RummerLab notes on shark physiology, reef science, Physioshark fieldwork, and public conversations about a changing ocean.',
+};
+
+const formatDate = (dateString: string): string => {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  } catch {
+    return dateString;
+  }
+};
+
+export default function BlogPage() {
+  const posts = getAllSiteBlogPosts();
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="max-w-3xl mx-auto text-center mb-12">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+          RummerLab blog
+        </h1>
+        <p className="text-xl text-gray-600 dark:text-gray-300">
+          Notes from the lab: shark and reef physiology, Physioshark fieldwork on Mo&apos;orea,
+          and the public conversations that follow the science.
+        </p>
+      </div>
+
+      <div className="max-w-5xl mx-auto space-y-8">
+        {posts.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-gray-600 dark:text-gray-400">
+              No posts yet. Check back soon!
+            </p>
+          </div>
+        ) : (
+          posts.map((post) => (
+            <article
+              key={post.slug}
+              className="bg-white dark:bg-gray-900 rounded-lg shadow-md hover:shadow-lg transition-shadow overflow-hidden"
+            >
+              <div
+                className={`flex flex-col gap-6 p-6 md:p-8 ${post.coverImage ? 'sm:flex-row sm:items-stretch' : ''}`}
+              >
+                {post.coverImage && (
+                  <Link
+                    href={`/blog/${sanitizeSlugForUrl(post.slug)}`}
+                    className="relative mx-auto w-full max-w-md shrink-0 overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800 aspect-16/10 sm:mx-0 sm:max-w-none sm:w-52 md:w-60 lg:w-64 sm:aspect-4/5 outline-offset-2 focus-visible:outline-2 focus-visible:outline-blue-500"
+                    aria-label={`Post image: ${post.title}`}
+                  >
+                    <Image
+                      src={post.coverImage}
+                      alt={post.coverImageAlt || post.title}
+                      fill
+                      className="object-cover transition-transform duration-300 hover:scale-[1.02]"
+                      sizes="(max-width: 639px) 100vw, 256px"
+                    />
+                  </Link>
+                )}
+
+                <div className="min-w-0 flex-1 flex flex-col">
+                  <div className="mb-4">
+                    <time
+                      className="text-sm text-gray-500 dark:text-gray-400"
+                      dateTime={post.date}
+                    >
+                      {formatDate(post.date)}
+                    </time>
+                  </div>
+
+                  <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+                    <Link
+                      href={`/blog/${sanitizeSlugForUrl(post.slug)}`}
+                      className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                    >
+                      {post.title}
+                    </Link>
+                  </h2>
+
+                  {post.excerpt && (
+                    <div className="prose prose-gray dark:prose-invert max-w-none mb-6">
+                      <p className="text-gray-600 dark:text-gray-300">{post.excerpt}</p>
+                    </div>
+                  )}
+
+                  <div className="mt-auto flex flex-wrap gap-4 items-center">
+                    <Link
+                      href={`/blog/${sanitizeSlugForUrl(post.slug)}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                    >
+                      Read more →
+                    </Link>
+                    {post.spotify && (
+                      <a
+                        href={post.spotify}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors text-sm"
+                      >
+                        🎧 Listen on Spotify
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -38,6 +38,16 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
+                <Link href="/blog" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">
+                  Blog
+                </Link>
+              </li>
+              <li>
+                <Link href="/podcast" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">
+                  Podcast
+                </Link>
+              </li>
+              <li>
                 <Link href="/team" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">
                   Team
                 </Link>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -121,6 +121,7 @@ export default function Navbar() {
                 { href: "/media", label: "Media" },
                 { href: "/gallery", label: "Gallery" },
                 { href: "/podcast", label: "Podcast" },
+                { href: "/blog", label: "Blog" },
             ]
         },
         { href: "/physioshark-project", label: "Physioshark" },

--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -48,7 +48,7 @@ After changing headers:
 curl.exe -sI https://rummerlab.com
 ```
 
-Check [securityheaders.com](https://securityheaders.com/?q=rummerlab.com) and smoke-test homepage, a podcast article, contact (Maps), Physioshark (map iframe), and `/api/scholar/ynWS968AAAAJ`.
+Check [securityheaders.com](https://securityheaders.com/?q=rummerlab.com) and smoke-test homepage, a podcast article, a blog post, contact (Maps), Physioshark (map iframe), and `/api/scholar/ynWS968AAAAJ`.
 
 ## CORS (not a security-header audit item)
 

--- a/lib/site-blog.ts
+++ b/lib/site-blog.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+import matter from '@11ty/gray-matter';
+import { remark } from 'remark';
+import remarkHtml from 'remark-html';
+import type { BlogGalleryImage, BlogPost } from '@/lib/blog';
+
+const blogsDirectory = path.join(process.cwd(), '_blog');
+
+export type { BlogGalleryImage, BlogPost };
+
+const processMarkdown = (content: string): string => {
+  const processedContent = remark().use(remarkHtml).processSync(content);
+  return processedContent.toString();
+};
+
+const toBlogPost = (slug: string, fileContents: string): BlogPost => {
+  const { data, content } = matter(fileContents);
+  const htmlContent = processMarkdown(content);
+
+  return {
+    slug,
+    title: data.title || '',
+    date: data.date || '',
+    excerpt: data.excerpt || undefined,
+    coverImage: data.coverImage || undefined,
+    coverImageAlt: data.coverImageAlt || undefined,
+    paper: data.paper || undefined,
+    podcast: data.podcast || undefined,
+    spotify: data.spotify || undefined,
+    youtube: data.youtube || undefined,
+    journal: data.journal || undefined,
+    journalUrl: data.journalUrl || undefined,
+    doi: data.doi || undefined,
+    gallery: data.gallery || undefined,
+    content,
+    htmlContent,
+  };
+};
+
+export const getAllSiteBlogPosts = (): BlogPost[] => {
+  if (!fs.existsSync(blogsDirectory)) {
+    return [];
+  }
+
+  const fileNames = fs.readdirSync(blogsDirectory);
+  const allPostsData = fileNames
+    .filter((fileName) => fileName.endsWith('.md'))
+    .map((fileName) => {
+      const slug = fileName.replace(/\.md$/, '');
+      const fullPath = path.join(blogsDirectory, fileName);
+      const fileContents = fs.readFileSync(fullPath, 'utf8');
+      return toBlogPost(slug, fileContents);
+    });
+
+  return allPostsData.sort((a, b) => {
+    const dateA = new Date(a.date).getTime();
+    const dateB = new Date(b.date).getTime();
+    return dateB - dateA;
+  });
+};
+
+export const getSiteBlogPostBySlug = (slug: string): BlogPost | null => {
+  if (slug.includes('..')) {
+    throw new Error('Invalid slug format');
+  }
+
+  const fullPath = path.join(blogsDirectory, `${slug}.md`);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
+
+  const fileContents = fs.readFileSync(fullPath, 'utf8');
+  return toBlogPost(slug, fileContents);
+};
+
+export const getAllSiteBlogSlugs = (): string[] => {
+  if (!fs.existsSync(blogsDirectory)) {
+    return [];
+  }
+
+  const fileNames = fs.readdirSync(blogsDirectory);
+  return fileNames
+    .filter((fileName) => fileName.endsWith('.md'))
+    .map((fileName) => fileName.replace(/\.md$/, ''));
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -93,16 +93,6 @@ const config: NextConfig = {
         destination: '/team',
         permanent: true,
       },
-      {
-        source: '/blog',
-        destination: '/podcast',
-        permanent: true,
-      },
-      {
-        source: '/blog/:slug',
-        destination: '/podcast/:slug',
-        permanent: true,
-      },
     ]
   },
   async headers() {


### PR DESCRIPTION
## Summary
- Add a `/blog` platform modelled on the podcast: markdown in `_blog/`, index at `/blog`, posts at `/blog/[slug]`.
- Remove the old `/blog` → `/podcast` redirects so the new routes can render.
- First post covers Jodie’s 15 June 2026 FINcast interview on newborn-shark research in French Polynesia (Physioshark on Mo'orea with science4reefs).

## Test plan
- [ ] Open `/blog` from the Media nav dropdown and footer
- [ ] Open `/blog/fincast-baby-shark-research-french-polynesia` and the Spotify listen button
- [ ] Confirm `/podcast` and existing episode URLs still work
- [ ] Confirm light and dark styles match the podcast pages

Made with [Cursor](https://cursor.com)