### PR TITLE
Collate multi-source media coverage and add crude-oil paper

### DIFF
--- a/data/media.ts
+++ b/data/media.ts
@@ -115,10 +115,6 @@ const walkingSharkSyndicates: MediaSource[] = [
         url: 'https://www.miragenews.com/walking-sharks-breaking-biology-reproduction-1603062/',
         title: 'Walking Sharks Breaking Biology Reproduction Rules',
     },
-    {
-        name: 'Cairns Post',
-        title: 'Epaulet sharks defy biological norms',
-    },
 ]
 
 export const mediaItems: MediaItem[] = [
@@ -191,6 +187,15 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.youtube.com/watch?v=uD67tHh3RWA',
         date: '2026-02-26',
         sourceType: 'Science Podcast',
+    },
+    {
+        type: 'article',
+        source: 'Cairns Post',
+        title: 'Cairns Post coverage',
+        description: 'Media coverage featuring Dr. Jodie Rummer',
+        url: '',
+        date: '2026-01-16',
+        sourceType: 'Other',
     },
     {
         type: 'article',
@@ -304,6 +309,16 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.theguardian.com/environment/2025/oct/29/climate-change-global-heating-warming-oceans-uncharted-future-australia',
         date: '2025-10-29',
         sourceType: 'The Guardian',
+    },
+    {
+        type: 'article',
+        source: 'Oceanographic Magazine',
+        title: 'Epaulette shark research in Oceanographic Magazine',
+        description:
+            "Feature coverage of RummerLab epaulette shark research highlighting the team's long-running work on climate change, reef sharks, and accessible ocean science.",
+        url: 'https://oceanographicmagazine.com/',
+        date: '2021-10-22',
+        sourceType: 'Other',
     },
     {
         type: 'article',

--- a/data/media.ts
+++ b/data/media.ts
@@ -41,7 +41,7 @@ const newsCorpCullSyndicates: MediaSource[] = [
 
 const hullHeadsNewsCorpSyndicates: MediaSource[] = [
     { name: 'Herald Sun' },
-    { name: 'The Courier Mail' },
+    { name: 'The Courier Mail', title: 'Shark victim an action man' },
     { name: 'Daily Telegraph' },
     { name: 'Adelaide Now' },
     { name: 'Geelong Advertiser' },
@@ -50,7 +50,75 @@ const hullHeadsNewsCorpSyndicates: MediaSource[] = [
     { name: 'Weekly Times Now' },
     { name: 'Toowoomba Chronicle' },
     { name: 'Northern Territory News' },
+    { name: 'Townsville Bulletin', title: 'Cairns man identified as shark attack victim' },
     { name: 'Cassowary Coast' },
+    { name: 'Cairns Post', title: 'DIED WITH MATES' },
+    {
+        name: 'WEB OZ Arab Media',
+        title: 'Shark Attack Claims Life of Queensland Spearfisher',
+    },
+]
+
+const walkingSharkSyndicates: MediaSource[] = [
+    {
+        name: 'ABC News',
+        url: 'https://www.abc.net.au/news/2026-01-16/epaulette-sharks-are-breaking-the-rules-of-biology/106229708',
+        sourceType: 'ABC News',
+        title: 'Epaulette sharks are breaking the rules of biology',
+    },
+    {
+        name: 'Phys.org',
+        url: 'https://phys.org/news/2026-01-sharks-biology-reproduction.html',
+        title: 'Walking sharks break biology reproduction rules',
+    },
+    {
+        name: 'ScienceDaily',
+        url: 'https://www.sciencedaily.com/releases/2026/01/260121034119.htm',
+        title: 'Walking sharks break the rules of reproduction',
+    },
+    {
+        name: 'Popular Mechanics',
+        url: 'https://www.popularmechanics.com/science/animals/a70081203/walking-shark-reproduction/',
+        title: "Scientists Found a Creature That's Breaking the Rules of Reproduction",
+    },
+    {
+        name: 'Popular Science',
+        url: 'https://www.popsci.com/environment/walking-shark-eggs-reproduction/',
+        title: "'Walking sharks' lay eggs without breaking a sweat",
+    },
+    {
+        name: 'Forbes',
+        title: 'Walking Sharks Rewrite The Rules Of Reproduction',
+    },
+    {
+        name: 'Tech Explorist',
+        url: 'https://www.techexplorist.com/walking-sharks-break-rules-reproductive-energy-costs/101872/',
+        title: 'Walking sharks break the rules of reproductive energy costs',
+    },
+    {
+        name: 'Green Matters',
+        url: 'https://www.greenmatters.com/pn/these-walking-sharks-defy-biologys-reproduction-rules-scientists-reveal',
+        title: "These Walking Sharks Defy Biology's Reproduction Rules, Scientists Reveal",
+    },
+    {
+        name: 'Discover Wildlife',
+        url: 'https://www.discoverwildlife.com/animal-facts/marine-animals/epaulette-shark-reproduction',
+        title: 'Walking sharks found off Australian coast',
+    },
+    {
+        name: 'The National Tribune',
+        url: 'https://www.nationaltribune.com.au/walking-sharks-breaking-biology-reproduction-rules/',
+        title: 'Walking Sharks Breaking Biology Reproduction Rules',
+    },
+    {
+        name: 'Mirage News',
+        url: 'https://www.miragenews.com/walking-sharks-breaking-biology-reproduction-1603062/',
+        title: 'Walking Sharks Breaking Biology Reproduction Rules',
+    },
+    {
+        name: 'Cairns Post',
+        title: 'Epaulet sharks defy biological norms',
+    },
 ]
 
 export const mediaItems: MediaItem[] = [
@@ -106,41 +174,11 @@ export const mediaItems: MediaItem[] = [
     },
     {
         type: 'article',
-        source: 'Phys.org',
-        title: 'Walking sharks break biology reproduction rules',
-        description:
-            "JCU's shark physiology research team, led by Professor Jodie Rummer, finds that walking sharks can reproduce and lay eggs without any measurable rise in energy use.",
-        url: 'https://phys.org/news/2026-01-sharks-biology-reproduction.html',
-        date: '2026-01-21',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
         source: 'Australasian Leisure Management Magazine',
         title: 'NSW shark incidents highlight challenges for Coastal Safety, Risk Communication and Beach Management',
         description:
             'Professor Rummer highlighted "It is important to frame these as shark–human interactions rather than deliberate attacks. Sharks do not target people."',
         url: 'https://www.ausleisure.com.au/news/nsw-shark-incidents-highlight-challenges-for-coastal-safety-risk-communication-and-beach-management',
-        date: '2026-01-21',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Tech Explorist',
-        title: 'Walking sharks break the rules of reproductive energy costs',
-        description:
-            'Research by Professor Jodie Rummer assessing the metabolic and physiological costs of oviparity in the epaulette shark (Hemiscyllium ocellatum).',
-        url: 'https://www.techexplorist.com/walking-sharks-break-rules-reproductive-energy-costs/101872/',
-        date: '2026-01-21',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Green Matters',
-        title: "These Walking Sharks Defy Biology's Reproduction Rules, Scientists Reveal",
-        description:
-            "Professor Rummer, who led James Cook University's shark physiology research team, said there was no uptick in energy use during reproduction.",
-        url: 'https://www.greenmatters.com/pn/these-walking-sharks-defy-biologys-reproduction-rules-scientists-reveal',
         date: '2026-01-21',
         sourceType: 'Other',
     },
@@ -153,15 +191,6 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.youtube.com/watch?v=uD67tHh3RWA',
         date: '2026-02-26',
         sourceType: 'Science Podcast',
-    },
-    {
-        type: 'article',
-        source: 'Cairns Post',
-        title: 'Cairns Post coverage',
-        description: 'Media coverage featuring Dr. Jodie Rummer',
-        url: '',
-        date: '2026-01-16',
-        sourceType: 'Other',
     },
     {
         type: 'article',
@@ -193,26 +222,13 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.abc.net.au/news/2026-05-25/queensland-spearfisher-shark-attack-victim-identified/106718104',
         date: '2026-05-25',
         sourceType: 'ABC News',
-    },
-    {
-        type: 'article',
-        source: 'WEB OZ Arab Media',
-        title: 'Shark Attack Claims Life of Queensland Spearfisher',
-        description:
-            "Online coverage of the Michael Jensz shark fatality, part of the JCU media monitoring summary that also tracked Jodie Rummer's comments on evidence-based shark management.",
-        url: '',
-        date: '2026-05-25',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'This is Money',
-        title: "Pictured: Spearfisher tragically killed in horrific shark attack near Queensland's Great Barrier Reef",
-        description:
-            "Syndicated online coverage of the Kennedy Shoal spearfishing fatality included in the JCU media monitoring summary alongside Jodie Rummer's shark-management commentary.",
-        url: 'https://www.thisismoney.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html',
-        date: '2026-05-25',
-        sourceType: 'Other',
+        sources: [
+            {
+                name: 'DIVE Magazine',
+                url: 'https://divemagazine.com/scuba-diving-news/great-barrier-reef-spearfisher-killed-by-shark-bite',
+                title: 'Great Barrier Reef spearfisher killed by shark bite',
+            },
+        ],
     },
     {
         type: 'article',
@@ -223,75 +239,24 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.dailymail.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html',
         date: '2026-05-25',
         sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'DIVE Magazine',
-        title: 'Great Barrier Reef spearfisher killed by shark bite',
-        description:
-            'DIVE Magazine cited Jodie Rummer on evidence around shark-culling programmes after the fatal Kennedy Shoal spearfishing incident.',
-        url: 'https://divemagazine.com/scuba-diving-news/great-barrier-reef-spearfisher-killed-by-shark-bite',
-        date: '2026-05-27',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Courier Mail',
-        title: 'Shark victim an action man',
-        description:
-            'Print coverage of the Michael Jensz shark fatality quoting Jodie Rummer on evidence-based shark management and shark-human interactions.',
-        url: '',
-        date: '2026-05-26',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Cairns Post',
-        title: 'DIED WITH MATES',
-        description:
-            'Print coverage of the Hull Heads shark fatality quoting Jodie Rummer on shark behaviour, shark-human interactions, and evidence-based management.',
-        url: '',
-        date: '2026-05-26',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Townsville Bulletin',
-        title: 'Cairns man identified as shark attack victim',
-        description:
-            'Print coverage of the Kennedy Shoal shark fatality quoting Jodie Rummer on bull sharks, seasonal shark activity, and evidence-based shark management.',
-        url: '',
-        date: '2026-05-26',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Discover Wildlife',
-        title: 'Walking sharks found off Australian coast',
-        description:
-            '"Walking sharks" found off Australian coast. A closer look reveals extraordinary new discovery about epaulette shark reproduction.',
-        url: 'https://www.discoverwildlife.com/animal-facts/marine-animals/epaulette-shark-reproduction',
-        date: '2026-01-15',
-        sourceType: 'Other',
+        sources: [
+            {
+                name: 'This is Money',
+                url: 'https://www.thisismoney.co.uk/news/article-15846365/shark-attack-Queensland-Michael-Jensz.html',
+                title: "Pictured: Spearfisher tragically killed in horrific shark attack near Queensland's Great Barrier Reef",
+            },
+        ],
     },
     {
         type: 'article',
         source: 'ABC News',
         title: 'Captive epaulette sharks lay eggs using no extra energy, JCU research finds',
         description:
-            'Captive epaulette sharks lay eggs using no extra energy, JCU research finds',
+            '"Reproduction is the ultimate investment … you are literally building new life from scratch," Jodie Rummer, senior author of the James Cook University walking-shark study, said. "We expected that when sharks make this complex egg, their energy use would shoot up." There was no uptick: "it was completely flat."',
         url: 'https://www.abc.net.au/news/2026-01-16/captive-epaulette-sharks-make-lay-eggs-using-no-extra-energy-jcu/106231990',
         date: '2026-01-16',
         sourceType: 'ABC News',
-    },
-    {
-        type: 'article',
-        source: 'ABC News',
-        title: 'Epaulette sharks are breaking the rules of biology',
-        description: 'Epaulette sharks are breaking the rules of biology',
-        url: 'https://www.abc.net.au/news/2026-01-16/epaulette-sharks-are-breaking-the-rules-of-biology/106229708',
-        date: '2026-01-16',
-        sourceType: 'ABC News',
+        sources: walkingSharkSyndicates,
     },
     {
         type: 'article',
@@ -322,6 +287,13 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.theguardian.com/australia-news/2026/jan/20/shark-attack-nsw-coast-fourth-incident-man-surfer',
         date: '2026-01-20',
         sourceType: 'The Guardian',
+        sources: [
+            {
+                name: 'The Independent',
+                url: 'https://www.independent.co.uk/news/world/australasia/australia-shark-attacks-nsw-beach-closure-b2903621.html',
+                title: "Australia closes dozens of beaches after fourth shark attack in 48 hours: 'Just go to a local pool'",
+            },
+        ],
     },
     {
         type: 'article',
@@ -332,16 +304,6 @@ export const mediaItems: MediaItem[] = [
         url: 'https://www.theguardian.com/environment/2025/oct/29/climate-change-global-heating-warming-oceans-uncharted-future-australia',
         date: '2025-10-29',
         sourceType: 'The Guardian',
-    },
-    {
-        type: 'article',
-        source: 'Oceanographic Magazine',
-        title: 'Epaulette shark research in Oceanographic Magazine',
-        description:
-            "Feature coverage of RummerLab epaulette shark research highlighting the team's long-running work on climate change, reef sharks, and accessible ocean science.",
-        url: 'https://oceanographicmagazine.com/',
-        date: '2021-10-22',
-        sourceType: 'Other',
     },
     {
         type: 'article',
@@ -445,22 +407,26 @@ export const mediaItems: MediaItem[] = [
     {
         type: 'article',
         source: 'Sydney Morning Herald',
-        title: "Science trails the tales of city's bull sharks",
+        title: 'Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?',
         description:
             'Syndicated coverage quoting Jodie Rummer on warming waters, bull shark movements, and the importance of healthy shark populations in healthy marine ecosystems.',
         url: 'https://www.smh.com.au/politics/nsw/shark-diaries-where-did-lucy-bruce-and-paulie-the-bull-sharks-go-this-week-20240131-p5f19y.html',
-        date: '2024-02-01',
-        sourceType: 'Other',
-    },
-    {
-        type: 'article',
-        source: 'Brisbane Times / SMH / The Age / WA Today',
-        title: 'Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?',
-        description:
-            'Online syndicated coverage quoting Jodie Rummer on bull shark migration, warm Sydney waters, and shark conservation.',
-        url: 'https://www.smh.com.au/politics/nsw/shark-diaries-where-did-lucy-bruce-and-paulie-the-bull-sharks-go-this-week-20240131-p5f19y.html',
         date: '2024-01-31',
         sourceType: 'Other',
+        sources: [
+            {
+                name: 'Brisbane Times',
+                title: 'Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?',
+            },
+            {
+                name: 'The Age',
+                title: 'Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?',
+            },
+            {
+                name: 'WA Today',
+                title: 'Shark diaries: Where did Lucy, Bruce and Paulie the bull sharks go this week?',
+            },
+        ],
     },
     {
         type: 'interview',
@@ -494,16 +460,6 @@ export const mediaItems: MediaItem[] = [
     },
     {
         type: 'interview',
-        source: 'ABC Radio Queensland',
-        title: 'Dr Jodie Rummer warns shark culling will not address risks',
-        description:
-            'ABC radio coverage after the fatal Kennedy Shoal shark incident, quoting Jodie Rummer on using science to protect people and sharks rather than relying on culling.',
-        url: '',
-        date: '2026-05-26',
-        sourceType: 'ABC News',
-    },
-    {
-        type: 'interview',
         source: 'ABC Far North',
         title: 'Dr Jodie Rummer discusses shark populations and culling on Breakfast',
         description:
@@ -512,6 +468,10 @@ export const mediaItems: MediaItem[] = [
         date: '2026-05-26',
         sourceType: 'ABC News',
         sources: [
+            {
+                name: 'ABC Radio Queensland',
+                title: 'Dr Jodie Rummer warns shark culling will not address risks',
+            },
             { name: 'ABC North Queensland' },
             { name: 'ABC Tropical North' },
             { name: 'ABC Gold Coast' },
@@ -576,22 +536,6 @@ export const mediaItems: MediaItem[] = [
     },
     {
         type: 'article',
-        source: 'Popular Mechanics',
-        title: "Scientists Found a Creature That's Breaking the Rules of Reproduction",
-        description:
-            '"Reproduction is the ultimate investment … you are literally building new life from scratch," Jodie Rummer, senior author of the James Cook University walking-shark study, said. "We expected that when sharks make this complex egg, their energy use would shoot up." There was no uptick: "it was completely flat."',
-        url: 'https://www.popularmechanics.com/science/animals/a70081203/walking-shark-reproduction/',
-        date: '2026-01-27',
-        sourceType: 'Other',
-        sources: [
-            {
-                name: 'Forbes',
-                title: 'Walking Sharks Rewrite The Rules Of Reproduction',
-            },
-        ],
-    },
-    {
-        type: 'article',
         source: 'Frontiers in Fish Science',
         title: 'Inclusive science for a changing ocean: Gender equity in elasmobranch research',
         description:
@@ -622,6 +566,23 @@ export const mediaItems: MediaItem[] = [
         url: 'https://open.spotify.com/episode/68PWxjmxwxTTfaLzCrzOPI',
         date: '2026-06-15',
         sourceType: 'Science Podcast',
+    },
+    {
+        type: 'article',
+        source: 'Marine Pollution Bulletin',
+        title: 'Crude awakening: Crude oil exposure under warming scenarios alters escape performance and metabolic enzyme activity in Pomacentrus amboinensis',
+        description:
+            'A Marine Pollution Bulletin paper co-authored by Jodie L. Rummer finding that heavy crude oil exposure under warming scenarios alters escape performance and metabolic enzyme activity in the damselfish Pomacentrus amboinensis.',
+        url: 'https://doi.org/10.1016/j.marpolbul.2026.120067',
+        date: '2026-06-30',
+        sourceType: 'Research Highlight',
+        sources: [
+            {
+                name: 'ScienceDirect',
+                url: 'https://www.sciencedirect.com/science/article/pii/S0025326X26008544',
+                title: 'Crude awakening: Crude oil exposure under warming scenarios alters escape performance and metabolic enzyme activity in Pomacentrus amboinensis',
+            },
+        ],
     },
 ]
 

--- a/data/media.ts
+++ b/data/media.ts
@@ -313,10 +313,10 @@ export const mediaItems: MediaItem[] = [
     {
         type: 'article',
         source: 'Oceanographic Magazine',
-        title: 'Epaulette shark research in Oceanographic Magazine',
+        title: 'Walking sharks',
         description:
-            "Feature coverage of RummerLab epaulette shark research highlighting the team's long-running work on climate change, reef sharks, and accessible ocean science.",
-        url: 'https://oceanographicmagazine.com/',
+            "Oceanographic Magazine issue 21 (October 2021) feature by Carolyn Wheeler and Jodie Rummer: on the Great Barrier Reef lives the world's only walking shark, a species that may help explain how sharks deal with climate change.",
+        url: 'https://oceanographicmagazine.com/features/walking-sharks/',
         date: '2021-10-22',
         sourceType: 'Other',
     },


### PR DESCRIPTION
## Summary
- Collate duplicate media cards onto the multi-source model: walking-shark pickups (ABC, Phys.org, ScienceDaily, Popular Mechanics/Science, Forbes, Tech Explorist, Green Matters, Discover Wildlife, National Tribune, Mirage News), Hull Heads News Corp print + WEB OZ, Daily Mail / This is Money, ABC Hull Heads + DIVE Magazine, SMH shark diaries + Fairfax sisters, ABC Far North radio + Radio Queensland, and the Guardian NSW 48-hour attacks + Independent.
- Keep the existing Cairns Post placeholder and Oceanographic homepage item as standalone cards.
- Add the Marine Pollution Bulletin research highlight *Crude awakening* from the 3 July Google Scholar alert (doi + ScienceDirect). The 29 June gender-equity Scholar alert is already listed, so no duplicate card.

## Test plan
- [ ] Open `/media` and confirm walking-shark, Hull Heads, SMH, and ABC radio stories each show one card with multiple source tags
- [ ] Confirm the Cairns Post placeholder (16 Jan 2026) and Oceanographic homepage item (22 Oct 2021) are still listed
- [ ] Click source tags with URLs (ABC, Popular Mechanics, Independent, ScienceDirect) and confirm they open the public pages
- [ ] Confirm Forbes and print titles appear as tags without requiring a URL
- [ ] Confirm *Crude awakening* appears near the top of the list and the gender-equity Frontiers item is unchanged