### PR TITLE
Add RummerLab icon to homepage and navbar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { AnimatedCollaborators } from '../components/AnimatedCollaborators';
+import { RummerLabMark } from '../components/RummerLabMark';
 import { TextReveal } from '../components/TextReveal';
 import { HeroParallax } from '../components/ui/hero-parallax';
 import { PlanktonCore } from '../components/ui/plankton';
@@ -43,6 +44,10 @@ export default function Home() {
               />
             </div>
             
+            <RummerLabMark
+              className="mb-6 rounded-2xl bg-white/90 px-4 py-3 shadow-lg backdrop-blur-sm"
+              imageClassName="h-auto w-52 sm:w-64 md:w-72"
+            />
             <h1 className="text-5xl md:text-7xl font-bold mb-4 tracking-tight">
               <span className="bg-clip-text text-transparent bg-linear-to-r from-blue-600 via-blue-400 to-cyan-400">
                 RummerLab

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { SiBluesky } from "react-icons/si"
 import { useState } from "react"
 import { IconType } from "react-icons"
 import type { ReactElement } from 'react'
+import { RummerLabMark } from "@/components/RummerLabMark"
 
 export default function Navbar() {
     const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -133,7 +134,11 @@ export default function Navbar() {
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="flex justify-between h-16">
                     <div className="flex items-center">
-                        <Link href="/" className="flex items-center group">
+                        <Link href="/" className="flex items-center gap-2.5 group" aria-label="RummerLab home">
+                            <RummerLabMark
+                                className="shrink-0 rounded-md bg-white p-0.5 shadow-sm ring-1 ring-black/5"
+                                imageClassName="h-8 w-auto sm:h-9"
+                            />
                             <span className="text-2xl font-bold text-gray-900 dark:text-gray-50 bg-clip-text text-transparent bg-linear-to-r from-blue-600 via-cyan-500 to-blue-600 dark:from-blue-400 dark:via-cyan-300 dark:to-blue-400 bg-size-[200%_100%] bg-position-[0%_50%] group-hover:bg-position-[100%_50%] transition-all duration-500 ease-in-out">
                                 RummerLab
                             </span>

--- a/components/RummerLabMark.tsx
+++ b/components/RummerLabMark.tsx
@@ -1,0 +1,21 @@
+import Image from 'next/image'
+
+interface RummerLabMarkProps {
+    className?: string
+    imageClassName?: string
+}
+
+export function RummerLabMark({ className, imageClassName }: RummerLabMarkProps) {
+    return (
+        <span className={['inline-flex items-center', className].filter(Boolean).join(' ')}>
+            <Image
+                src="/RummerLab_icon.svg"
+                alt=""
+                width={261}
+                height={123}
+                unoptimized
+                className={imageClassName ?? 'h-full w-auto'}
+            />
+        </span>
+    )
+}


### PR DESCRIPTION
## Summary
- Keep the existing blue/cyan gradient **RummerLab** wordmark.
- Add `public/RummerLab_icon.svg` above the homepage hero title and beside the navbar wordmark.
- Sit the mark on a light plate so the black-and-teal artwork stays readable on the dark hero and in dark mode.

Closes #140

## Test plan
- [ ] Homepage hero shows the SVG logo above the gradient RummerLab text
- [ ] Navbar shows the icon + gradient RummerLab text; clicking it goes home
- [ ] Logo remains readable in light and dark mode
- [ ] Mobile navbar still fits icon + wordmark + menu button

Made with [Cursor](https://cursor.com)