### PR TITLE
Improve media page tags, colours, and type badges

### DIFF
--- a/app/media/MediaCoverageList.tsx
+++ b/app/media/MediaCoverageList.tsx
@@ -4,28 +4,9 @@ import { useMemo, useState } from "react";
 import { DEFAULT_SCHOLAR_ID } from "@/lib/news";
 import { getMediaSources, type MediaItem } from "@/types/media";
 import { ArticleImage } from "./ArticleImage";
+import { MediaSourceTags } from "./MediaSourceTags";
 
 const DEFAULT_LIMIT = 100;
-
-const getSourceColors = (sourceType: string): { bgColor: string; textColor: string } => {
-  switch (sourceType) {
-    case "The Conversation":
-      return {
-        bgColor: "bg-blue-100 dark:bg-blue-900",
-        textColor: "text-blue-800 dark:text-blue-200",
-      };
-    case "The Guardian":
-      return {
-        bgColor: "bg-green-100 dark:bg-green-900",
-        textColor: "text-green-800 dark:text-green-200",
-      };
-    default:
-      return {
-        bgColor: "bg-purple-100 dark:bg-purple-900",
-        textColor: "text-purple-800 dark:text-purple-200",
-      };
-  }
-};
 
 const hasValidUrl = (url?: string): boolean => {
   if (!url || typeof url !== "string") return false;
@@ -114,36 +95,10 @@ export function MediaCoverageList(props: Props) {
             <div className="flex flex-col md:flex-row">
               {article.image && <ArticleImage image={article.image} />}
               <div className="flex-1 p-6">
-                <div className="flex flex-wrap gap-2 mb-4">
-                  {outlets.map((outlet) => {
-                    const { bgColor, textColor } = getSourceColors(
-                      outlet.sourceType ?? article.sourceType
-                    );
-                    const outletUrlOk = hasValidUrl(outlet.url);
-                    const tagClassName = `inline-block px-2 py-1 text-sm font-medium ${bgColor} ${textColor} rounded-sm`;
-
-                    if (!outletUrlOk) {
-                      return (
-                        <span key={outlet.name} className={tagClassName}>
-                          {outlet.name}
-                        </span>
-                      );
-                    }
-
-                    return (
-                      <a
-                        key={outlet.name}
-                        href={outlet.url}
-                        className={`${tagClassName} hover:opacity-80 transition-opacity`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`${outlet.name} (opens in new tab)`}
-                      >
-                        {outlet.name}
-                      </a>
-                    );
-                  })}
-                </div>
+                <MediaSourceTags
+                  outlets={outlets}
+                  fallbackSourceType={article.sourceType}
+                />
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
                   {urlOk ? (
                     <a

--- a/app/media/MediaCoverageList.tsx
+++ b/app/media/MediaCoverageList.tsx
@@ -8,6 +8,13 @@ import { MediaSourceTags } from "./MediaSourceTags";
 
 const DEFAULT_LIMIT = 100;
 
+const MEDIA_TYPE_LABELS: Record<MediaItem["type"], string> = {
+  article: "News article",
+  interview: "Interview",
+  podcast: "Podcast",
+  press: "Press release",
+};
+
 const hasValidUrl = (url?: string): boolean => {
   if (!url || typeof url !== "string") return false;
   const trimmed = url.trim();
@@ -95,6 +102,11 @@ export function MediaCoverageList(props: Props) {
             <div className="flex flex-col md:flex-row">
               {article.image && <ArticleImage image={article.image} />}
               <div className="flex-1 p-6">
+                <div className="mb-3">
+                  <span className="inline-block px-2 py-0.5 text-xs font-semibold uppercase tracking-wide rounded-sm bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                    {MEDIA_TYPE_LABELS[article.type]}
+                  </span>
+                </div>
                 <MediaSourceTags outlets={outlets} />
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
                   {urlOk ? (

--- a/app/media/MediaCoverageList.tsx
+++ b/app/media/MediaCoverageList.tsx
@@ -95,10 +95,7 @@ export function MediaCoverageList(props: Props) {
             <div className="flex flex-col md:flex-row">
               {article.image && <ArticleImage image={article.image} />}
               <div className="flex-1 p-6">
-                <MediaSourceTags
-                  outlets={outlets}
-                  fallbackSourceType={article.sourceType}
-                />
+                <MediaSourceTags outlets={outlets} />
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
                   {urlOk ? (
                     <a

--- a/app/media/MediaSourceTags.tsx
+++ b/app/media/MediaSourceTags.tsx
@@ -53,7 +53,6 @@ export function MediaSourceTags({ outlets }: MediaSourceTagsProps) {
 
   const visibleOutlets = outlets.slice(0, VISIBLE_SOURCE_LIMIT);
   const overflowCount = Math.max(0, outlets.length - VISIBLE_SOURCE_LIMIT);
-  const shownOutlets = isExpanded ? outlets : visibleOutlets;
 
   useEffect(() => {
     if (!isExpanded) {
@@ -93,7 +92,7 @@ export function MediaSourceTags({ outlets }: MediaSourceTagsProps) {
 
   return (
     <div ref={rootRef} className="flex flex-wrap gap-2 mb-4">
-      {shownOutlets.map((outlet, index) => (
+      {visibleOutlets.map((outlet, index) => (
         <SourceTag key={`source-${index}`} outlet={outlet} />
       ))}
 
@@ -112,6 +111,14 @@ export function MediaSourceTags({ outlets }: MediaSourceTagsProps) {
           {isExpanded ? "Show less" : `+${overflowCount} more`}
         </button>
       )}
+
+      {isExpanded &&
+        outlets.slice(VISIBLE_SOURCE_LIMIT).map((outlet, index) => (
+          <SourceTag
+            key={`source-overflow-${VISIBLE_SOURCE_LIMIT + index}`}
+            outlet={outlet}
+          />
+        ))}
     </div>
   );
 }

--- a/app/media/MediaSourceTags.tsx
+++ b/app/media/MediaSourceTags.tsx
@@ -78,7 +78,7 @@ export function MediaSourceTags({ outlets, fallbackSourceType }: MediaSourceTags
     <div className="flex flex-wrap gap-2 mb-4">
       {visibleOutlets.map((outlet, index) => (
         <SourceTag
-          key={`${outlet.name}-${outlet.url ?? index}`}
+          key={`source-${index}`}
           outlet={outlet}
           fallbackSourceType={fallbackSourceType}
         />
@@ -103,7 +103,7 @@ export function MediaSourceTags({ outlets, fallbackSourceType }: MediaSourceTags
             <div className="flex flex-wrap gap-2">
               {overflowOutlets.map((outlet, index) => (
                 <SourceTag
-                  key={`${outlet.name}-${outlet.url ?? `overflow-${index}`}`}
+                  key={`source-overflow-${VISIBLE_SOURCE_LIMIT + index}`}
                   outlet={outlet}
                   fallbackSourceType={fallbackSourceType}
                 />

--- a/app/media/MediaSourceTags.tsx
+++ b/app/media/MediaSourceTags.tsx
@@ -1,29 +1,10 @@
 "use client";
 
 import { useId } from "react";
-import type { MediaItem, MediaSource } from "@/types/media";
+import type { MediaSource } from "@/types/media";
+import { getSourceTagColors } from "./sourceTagColors";
 
 const VISIBLE_SOURCE_LIMIT = 4;
-
-const getSourceColors = (sourceType: string): { bgColor: string; textColor: string } => {
-  switch (sourceType) {
-    case "The Conversation":
-      return {
-        bgColor: "bg-blue-100 dark:bg-blue-900",
-        textColor: "text-blue-800 dark:text-blue-200",
-      };
-    case "The Guardian":
-      return {
-        bgColor: "bg-green-100 dark:bg-green-900",
-        textColor: "text-green-800 dark:text-green-200",
-      };
-    default:
-      return {
-        bgColor: "bg-purple-100 dark:bg-purple-900",
-        textColor: "text-purple-800 dark:text-purple-200",
-      };
-  }
-};
 
 const hasValidUrl = (url?: string): boolean => {
   if (!url || typeof url !== "string") return false;
@@ -39,11 +20,10 @@ const hasValidUrl = (url?: string): boolean => {
 
 interface SourceTagProps {
   outlet: MediaSource;
-  fallbackSourceType: MediaItem["sourceType"];
 }
 
-function SourceTag({ outlet, fallbackSourceType }: SourceTagProps) {
-  const { bgColor, textColor } = getSourceColors(outlet.sourceType ?? fallbackSourceType);
+function SourceTag({ outlet }: SourceTagProps) {
+  const { bgColor, textColor } = getSourceTagColors(outlet.name);
   const tagClassName = `inline-block px-2 py-1 text-sm font-medium ${bgColor} ${textColor} rounded-sm`;
 
   if (!hasValidUrl(outlet.url)) {
@@ -65,10 +45,9 @@ function SourceTag({ outlet, fallbackSourceType }: SourceTagProps) {
 
 interface MediaSourceTagsProps {
   outlets: MediaSource[];
-  fallbackSourceType: MediaItem["sourceType"];
 }
 
-export function MediaSourceTags({ outlets, fallbackSourceType }: MediaSourceTagsProps) {
+export function MediaSourceTags({ outlets }: MediaSourceTagsProps) {
   const tooltipId = useId();
   const visibleOutlets = outlets.slice(0, VISIBLE_SOURCE_LIMIT);
   const overflowOutlets = outlets.slice(VISIBLE_SOURCE_LIMIT);
@@ -77,11 +56,7 @@ export function MediaSourceTags({ outlets, fallbackSourceType }: MediaSourceTags
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {visibleOutlets.map((outlet, index) => (
-        <SourceTag
-          key={`source-${index}`}
-          outlet={outlet}
-          fallbackSourceType={fallbackSourceType}
-        />
+        <SourceTag key={`source-${index}`} outlet={outlet} />
       ))}
 
       {overflowCount > 0 && (
@@ -105,7 +80,6 @@ export function MediaSourceTags({ outlets, fallbackSourceType }: MediaSourceTags
                 <SourceTag
                   key={`source-overflow-${VISIBLE_SOURCE_LIMIT + index}`}
                   outlet={outlet}
-                  fallbackSourceType={fallbackSourceType}
                 />
               ))}
             </div>

--- a/app/media/MediaSourceTags.tsx
+++ b/app/media/MediaSourceTags.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useId } from "react";
+import type { MediaItem, MediaSource } from "@/types/media";
+
+const VISIBLE_SOURCE_LIMIT = 4;
+
+const getSourceColors = (sourceType: string): { bgColor: string; textColor: string } => {
+  switch (sourceType) {
+    case "The Conversation":
+      return {
+        bgColor: "bg-blue-100 dark:bg-blue-900",
+        textColor: "text-blue-800 dark:text-blue-200",
+      };
+    case "The Guardian":
+      return {
+        bgColor: "bg-green-100 dark:bg-green-900",
+        textColor: "text-green-800 dark:text-green-200",
+      };
+    default:
+      return {
+        bgColor: "bg-purple-100 dark:bg-purple-900",
+        textColor: "text-purple-800 dark:text-purple-200",
+      };
+  }
+};
+
+const hasValidUrl = (url?: string): boolean => {
+  if (!url || typeof url !== "string") return false;
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+interface SourceTagProps {
+  outlet: MediaSource;
+  fallbackSourceType: MediaItem["sourceType"];
+}
+
+function SourceTag({ outlet, fallbackSourceType }: SourceTagProps) {
+  const { bgColor, textColor } = getSourceColors(outlet.sourceType ?? fallbackSourceType);
+  const tagClassName = `inline-block px-2 py-1 text-sm font-medium ${bgColor} ${textColor} rounded-sm`;
+
+  if (!hasValidUrl(outlet.url)) {
+    return <span className={tagClassName}>{outlet.name}</span>;
+  }
+
+  return (
+    <a
+      href={outlet.url}
+      className={`${tagClassName} hover:opacity-80 transition-opacity`}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`${outlet.name} (opens in new tab)`}
+    >
+      {outlet.name}
+    </a>
+  );
+}
+
+interface MediaSourceTagsProps {
+  outlets: MediaSource[];
+  fallbackSourceType: MediaItem["sourceType"];
+}
+
+export function MediaSourceTags({ outlets, fallbackSourceType }: MediaSourceTagsProps) {
+  const tooltipId = useId();
+  const visibleOutlets = outlets.slice(0, VISIBLE_SOURCE_LIMIT);
+  const overflowOutlets = outlets.slice(VISIBLE_SOURCE_LIMIT);
+  const overflowCount = overflowOutlets.length;
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {visibleOutlets.map((outlet, index) => (
+        <SourceTag
+          key={`${outlet.name}-${outlet.url ?? index}`}
+          outlet={outlet}
+          fallbackSourceType={fallbackSourceType}
+        />
+      ))}
+
+      {overflowCount > 0 && (
+        <div className="relative group/more">
+          <button
+            type="button"
+            className="inline-block px-2 py-1 text-sm font-medium rounded-sm bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:opacity-80 transition-opacity cursor-default"
+            aria-label={`${overflowCount} more sources`}
+            aria-describedby={tooltipId}
+          >
+            +{overflowCount} more
+          </button>
+
+          <div
+            id={tooltipId}
+            role="tooltip"
+            className="invisible opacity-0 group-hover/more:visible group-hover/more:opacity-100 group-focus-within/more:visible group-focus-within/more:opacity-100 transition-opacity absolute left-0 top-full z-20 mt-2 w-max max-w-xs sm:max-w-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 p-3 shadow-lg"
+          >
+            <div className="flex flex-wrap gap-2">
+              {overflowOutlets.map((outlet, index) => (
+                <SourceTag
+                  key={`${outlet.name}-${outlet.url ?? `overflow-${index}`}`}
+                  outlet={outlet}
+                  fallbackSourceType={fallbackSourceType}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/media/MediaSourceTags.tsx
+++ b/app/media/MediaSourceTags.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { MediaSource } from "@/types/media";
 import { getSourceTagColors } from "./sourceTagColors";
 
@@ -48,43 +48,69 @@ interface MediaSourceTagsProps {
 }
 
 export function MediaSourceTags({ outlets }: MediaSourceTagsProps) {
-  const tooltipId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+
   const visibleOutlets = outlets.slice(0, VISIBLE_SOURCE_LIMIT);
-  const overflowOutlets = outlets.slice(VISIBLE_SOURCE_LIMIT);
-  const overflowCount = overflowOutlets.length;
+  const overflowCount = Math.max(0, outlets.length - VISIBLE_SOURCE_LIMIT);
+  const shownOutlets = isExpanded ? outlets : visibleOutlets;
+
+  useEffect(() => {
+    if (!isExpanded) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      if (!rootRef.current?.contains(target)) {
+        setIsExpanded(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isExpanded]);
+
+  const handleToggle = () => {
+    setIsExpanded((open) => !open);
+  };
 
   return (
-    <div className="flex flex-wrap gap-2 mb-4">
-      {visibleOutlets.map((outlet, index) => (
+    <div ref={rootRef} className="flex flex-wrap gap-2 mb-4">
+      {shownOutlets.map((outlet, index) => (
         <SourceTag key={`source-${index}`} outlet={outlet} />
       ))}
 
       {overflowCount > 0 && (
-        <div className="relative group/more">
-          <button
-            type="button"
-            className="inline-block px-2 py-1 text-sm font-medium rounded-sm bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:opacity-80 transition-opacity cursor-default"
-            aria-label={`${overflowCount} more sources`}
-            aria-describedby={tooltipId}
-          >
-            +{overflowCount} more
-          </button>
-
-          <div
-            id={tooltipId}
-            role="tooltip"
-            className="invisible opacity-0 group-hover/more:visible group-hover/more:opacity-100 group-focus-within/more:visible group-focus-within/more:opacity-100 transition-opacity absolute left-0 top-full z-20 mt-2 w-max max-w-xs sm:max-w-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 p-3 shadow-lg"
-          >
-            <div className="flex flex-wrap gap-2">
-              {overflowOutlets.map((outlet, index) => (
-                <SourceTag
-                  key={`source-overflow-${VISIBLE_SOURCE_LIMIT + index}`}
-                  outlet={outlet}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
+        <button
+          type="button"
+          className="inline-block px-2 py-1 text-sm font-medium rounded-sm bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:opacity-80 transition-opacity"
+          aria-expanded={isExpanded}
+          aria-label={
+            isExpanded
+              ? "Hide additional sources"
+              : `Show ${overflowCount} more sources`
+          }
+          onClick={handleToggle}
+        >
+          {isExpanded ? "Show less" : `+${overflowCount} more`}
+        </button>
       )}
     </div>
   );

--- a/app/media/sourceTagColors.ts
+++ b/app/media/sourceTagColors.ts
@@ -1,0 +1,301 @@
+export interface SourceTagColors {
+  bgColor: string;
+  textColor: string;
+}
+
+const GREY: SourceTagColors = {
+  bgColor: "bg-gray-100 dark:bg-gray-700",
+  textColor: "text-gray-700 dark:text-gray-200",
+};
+
+/** Soft brand-inspired palettes for major / quality outlets. Unknown names fall back to grey. */
+const OUTLET_COLORS: Record<string, SourceTagColors> = {
+  // ABC family
+  "ABC News": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+  "ABC Far North": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+  "ABC Gold Coast": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+  "ABC North Queensland": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+  "ABC Radio": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+  "ABC Radio Queensland": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+  "ABC Tropical North": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-800 dark:text-blue-200",
+  },
+
+  // National / broadsheet
+  "The Conversation": {
+    bgColor: "bg-rose-100 dark:bg-rose-900",
+    textColor: "text-rose-800 dark:text-rose-200",
+  },
+  "The Guardian": {
+    bgColor: "bg-indigo-100 dark:bg-indigo-900",
+    textColor: "text-indigo-900 dark:text-indigo-200",
+  },
+  "The Age": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-900 dark:text-sky-200",
+  },
+  "Sydney Morning Herald": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-900 dark:text-sky-200",
+  },
+  "Brisbane Times": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-900 dark:text-sky-200",
+  },
+  "WA Today": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-900 dark:text-sky-200",
+  },
+  "The Australian": {
+    bgColor: "bg-slate-200 dark:bg-slate-700",
+    textColor: "text-slate-900 dark:text-slate-100",
+  },
+  "The Independent": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "RNZ": {
+    bgColor: "bg-cyan-100 dark:bg-cyan-900",
+    textColor: "text-cyan-900 dark:text-cyan-200",
+  },
+
+  // TV / broadcast
+  "9News": {
+    bgColor: "bg-amber-100 dark:bg-amber-900",
+    textColor: "text-amber-900 dark:text-amber-200",
+  },
+  "WIN News": {
+    bgColor: "bg-violet-100 dark:bg-violet-900",
+    textColor: "text-violet-800 dark:text-violet-200",
+  },
+  "WIN News Central Queensland": {
+    bgColor: "bg-violet-100 dark:bg-violet-900",
+    textColor: "text-violet-800 dark:text-violet-200",
+  },
+  "WIN News Darling Downs": {
+    bgColor: "bg-violet-100 dark:bg-violet-900",
+    textColor: "text-violet-800 dark:text-violet-200",
+  },
+  "WGBH": {
+    bgColor: "bg-fuchsia-100 dark:bg-fuchsia-900",
+    textColor: "text-fuchsia-800 dark:text-fuchsia-200",
+  },
+  "Science Friday": {
+    bgColor: "bg-fuchsia-100 dark:bg-fuchsia-900",
+    textColor: "text-fuchsia-800 dark:text-fuchsia-200",
+  },
+
+  // News Corp / metro tabloids
+  "news.com.au": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Herald Sun": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "The Courier Mail": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Daily Telegraph": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Adelaide Now": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "PerthNow": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Geelong Advertiser": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Gold Coast Bulletin": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "The Mercury": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Townsville Bulletin": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Cairns Post": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Northern Territory News": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Weekly Times Now": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "Toowoomba Chronicle": {
+    bgColor: "bg-red-100 dark:bg-red-900",
+    textColor: "text-red-800 dark:text-red-200",
+  },
+  "West Australian": {
+    bgColor: "bg-orange-100 dark:bg-orange-900",
+    textColor: "text-orange-900 dark:text-orange-200",
+  },
+  "Daily Mail Australia": {
+    bgColor: "bg-blue-100 dark:bg-blue-950",
+    textColor: "text-blue-900 dark:text-blue-200",
+  },
+  "This is Money": {
+    bgColor: "bg-blue-100 dark:bg-blue-950",
+    textColor: "text-blue-900 dark:text-blue-200",
+  },
+
+  // Science / research
+  Nature: {
+    bgColor: "bg-red-100 dark:bg-red-950",
+    textColor: "text-red-900 dark:text-red-200",
+  },
+  "Phys.org": {
+    bgColor: "bg-violet-100 dark:bg-violet-900",
+    textColor: "text-violet-800 dark:text-violet-200",
+  },
+  ScienceDaily: {
+    bgColor: "bg-cyan-100 dark:bg-cyan-900",
+    textColor: "text-cyan-900 dark:text-cyan-200",
+  },
+  ScienceDirect: {
+    bgColor: "bg-orange-100 dark:bg-orange-900",
+    textColor: "text-orange-900 dark:text-orange-200",
+  },
+  "Frontiers in Fish Science": {
+    bgColor: "bg-teal-100 dark:bg-teal-900",
+    textColor: "text-teal-900 dark:text-teal-200",
+  },
+  "Marine Pollution Bulletin": {
+    bgColor: "bg-teal-100 dark:bg-teal-900",
+    textColor: "text-teal-900 dark:text-teal-200",
+  },
+  "Cosmos Magazine": {
+    bgColor: "bg-purple-100 dark:bg-purple-900",
+    textColor: "text-purple-800 dark:text-purple-200",
+  },
+  "Oceanographic Magazine": {
+    bgColor: "bg-teal-100 dark:bg-teal-900",
+    textColor: "text-teal-800 dark:text-teal-200",
+  },
+  IFLScience: {
+    bgColor: "bg-pink-100 dark:bg-pink-900",
+    textColor: "text-pink-800 dark:text-pink-200",
+  },
+  "Popular Science": {
+    bgColor: "bg-yellow-100 dark:bg-yellow-900",
+    textColor: "text-yellow-900 dark:text-yellow-200",
+  },
+  "Popular Mechanics": {
+    bgColor: "bg-orange-100 dark:bg-orange-900",
+    textColor: "text-orange-900 dark:text-orange-200",
+  },
+  Forbes: {
+    bgColor: "bg-emerald-100 dark:bg-emerald-900",
+    textColor: "text-emerald-900 dark:text-emerald-200",
+  },
+  "Discover Wildlife": {
+    bgColor: "bg-lime-100 dark:bg-lime-900",
+    textColor: "text-lime-900 dark:text-lime-200",
+  },
+  "Green Matters": {
+    bgColor: "bg-green-100 dark:bg-green-900",
+    textColor: "text-green-800 dark:text-green-200",
+  },
+  "DIVE Magazine": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-800 dark:text-sky-200",
+  },
+
+  // Universities / institutions
+  "James Cook University": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-900 dark:text-blue-200",
+  },
+  "JCU News": {
+    bgColor: "bg-blue-100 dark:bg-blue-900",
+    textColor: "text-blue-900 dark:text-blue-200",
+  },
+  "Australian Marine Conservation Society": {
+    bgColor: "bg-teal-100 dark:bg-teal-900",
+    textColor: "text-teal-900 dark:text-teal-200",
+  },
+
+  // Aggregators / lifestyle
+  "Yahoo News Australia": {
+    bgColor: "bg-purple-100 dark:bg-purple-900",
+    textColor: "text-purple-800 dark:text-purple-200",
+  },
+  "Yahoo Lifestyle Australia": {
+    bgColor: "bg-purple-100 dark:bg-purple-900",
+    textColor: "text-purple-800 dark:text-purple-200",
+  },
+  "MSN Australia": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-800 dark:text-sky-200",
+  },
+  "MSN UK": {
+    bgColor: "bg-sky-100 dark:bg-sky-900",
+    textColor: "text-sky-800 dark:text-sky-200",
+  },
+};
+
+const PREFIX_COLORS: { prefix: string; colors: SourceTagColors }[] = [
+  {
+    prefix: "ABC ",
+    colors: {
+      bgColor: "bg-blue-100 dark:bg-blue-900",
+      textColor: "text-blue-800 dark:text-blue-200",
+    },
+  },
+  {
+    prefix: "WIN News",
+    colors: {
+      bgColor: "bg-violet-100 dark:bg-violet-900",
+      textColor: "text-violet-800 dark:text-violet-200",
+    },
+  },
+];
+
+export function getSourceTagColors(outletName: string): SourceTagColors {
+  const exact = OUTLET_COLORS[outletName];
+  if (exact) {
+    return exact;
+  }
+
+  const prefixMatch = PREFIX_COLORS.find(({ prefix }) => outletName.startsWith(prefix));
+  if (prefixMatch) {
+    return prefixMatch.colors;
+  }
+
+  return GREY;
+}

--- a/app/media/sourceTagColors.ts
+++ b/app/media/sourceTagColors.ts
@@ -66,8 +66,8 @@ const OUTLET_COLORS: Record<string, SourceTagColors> = {
     textColor: "text-sky-900 dark:text-sky-200",
   },
   "The Australian": {
-    bgColor: "bg-slate-200 dark:bg-slate-700",
-    textColor: "text-slate-900 dark:text-slate-100",
+    bgColor: "bg-blue-200 dark:bg-blue-950",
+    textColor: "text-blue-950 dark:text-blue-100",
   },
   "The Independent": {
     bgColor: "bg-red-100 dark:bg-red-900",

--- a/types/media.ts
+++ b/types/media.ts
@@ -37,7 +37,28 @@ export const getMediaSources = (item: MediaItem): MediaSource[] => {
         title: item.title,
     };
 
-    return [primary, ...(item.sources ?? [])];
+    const outlets = [primary, ...(item.sources ?? [])];
+    const seenExact = new Set<string>();
+    const seenNames = new Set<string>();
+
+    // Keep same-name outlets when they have distinct URLs (e.g. Conversation language editions).
+    // Drop duplicates that only repeat the outlet name without a new link.
+    return outlets.filter((outlet) => {
+        const url = outlet.url?.trim() || '';
+        const exactKey = `${outlet.name}::${url}`;
+
+        if (seenExact.has(exactKey)) {
+            return false;
+        }
+
+        if (!url && seenNames.has(outlet.name)) {
+            return false;
+        }
+
+        seenExact.add(exactKey);
+        seenNames.add(outlet.name);
+        return true;
+    });
 };
 
 export interface RSSItem {


### PR DESCRIPTION
## Summary
- Collapse long syndication lists to 4 source tags with a `+N more` hover overflow
- Colour major outlet tags by brand (ABC blue, Guardian indigo, etc.) with grey fallback
- Deduplicate repeated outlet names that do not add a new URL; fix React key warnings
- Show each card''s existing `type` as a badge (News article, Interview, Podcast, Press release)

## Test plan
- [ ] Open `/media` and confirm cards show a type badge above the outlet tags
- [ ] Find a card with many syndications and verify only 4 tags + `+N more` appear
- [ ] Hover `+N more` and confirm remaining outlet links work
- [ ] Confirm ABC News is blue, The Australian is navy, and unknown outlets are grey
- [ ] Confirm no duplicate-key console warnings for repeated outlet names