### PR TITLE
chore: release 0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rummerlab",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rummerlab",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@11ty/gray-matter": "^3.0.0",
         "@next/third-parties": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rummerlab",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bump package.json version to 0.1.6 for release v0.1.6.

Made with [Cursor](https://cursor.com)