### PR TITLE
Add AGENTS.md and PR merge guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,10 @@ npx @tailwindcss/upgrade
 
 After either upgrade: run `npm run lint` and `npm run build`, fix failures, and update this file if versions/scripts change.
 
+
+## Pull requests
+
+Before merging any pull request:
+
+1. **Read all comments** on the PR — conversation comments, review comments (including those on specific lines), and bot comments. Address or acknowledge them. Do not merge while review feedback is unresolved.
+2. **Wait for CI to complete successfully.** GitHub Actions (and other required checks) on the PR must finish and pass. Do not merge while checks are pending, failed, cancelled, or skipped when they are required. If CI fails, fix the cause and wait for a green run before merging.


### PR DESCRIPTION
## Summary
- Add or update `AGENTS.md` as the agent source of truth ([agents.md](https://agents.md/)).
- Migrate any `.cursor/rules/*.mdc` into `AGENTS.md` and remove those Cursor rule files.
- Instruct agents to **read all PR comments** and **wait for CI to succeed** before merging.

## Test plan
- [ ] Confirm `AGENTS.md` is present and includes the Pull requests section
- [ ] Confirm `.cursor/rules` is gone if it previously existed
