### PR TITLE
Add citation metadata for hosted paper PDFs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ If you suspect a security issue, run `snyk test`.
 - Early returns, DRY, `handle` prefix on event handlers (`handleClick`).
 - Style with Tailwind. Support light and dark classes already used on the site.
 - Media cards live in `data/media.json`. Helpers stay in `data/media.ts`. `url` is optional. Use `sources` for syndications of the same story; the primary `source`/`url` should be the strongest public outlet. Clickable source tags open that outlet's URL.
-- Hosted PDFs live in `public/papers/`. Listing and featured selection live in `lib/papers.ts`. Featured papers are the newest by year in the filename. Sister sites consume `GET /api/papers` and `GET /api/papers/featured`.
+- Hosted PDFs live in `public/papers/`. Listing and featured selection live in `lib/papers.ts`. Citation metadata (title, authors, journal, DOI, abstract) lives in `data/papers.json` keyed by PDF filename and is merged into API responses. Featured papers are the newest by year in the filename. Sister sites consume `GET /api/papers` and `GET /api/papers/featured`.
 - Mailbox catch-up for Google Alerts / digests / Isentia PDFs: follow [`MEDIA-ALERTS.md`](MEDIA-ALERTS.md).
 - Use `git mv` when moving files.
 - Complete the change: no TODOs or placeholders. File a GitHub issue for follow-up work instead of leaving TODO comments or README notes.

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 import { PublicationsCards } from "@/components/PublicationsCards"
+import { PaperCitation } from '@/components/PaperCitation';
 import Link from 'next/link';
-import { getPapers } from '@/lib/papers';
+import { getPaperDisplayName, getPapers } from '@/lib/papers';
 
 export const metadata: Metadata = {
   title: "Publications | RummerLab",
@@ -29,21 +30,28 @@ export default async function Publications() {
           <div className="max-w-4xl mx-auto">
             <div className="space-y-3">
               {papers.map((paper) => {
+                const displayName = getPaperDisplayName(paper);
                 return (
                   <div
                     key={paper.filename}
                     className="bg-white dark:bg-gray-900 rounded-lg shadow-md hover:shadow-lg transition-shadow p-4 md:p-6"
                   >
-                    <Link
-                      href={paper.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-between group"
-                    >
-                      <span className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors flex-1">
-                        {paper.name}
-                      </span>
-                      <span className="ml-4 text-blue-600 dark:text-blue-400 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="flex items-start justify-between gap-4 group">
+                      <div className="flex-1 min-w-0">
+                        {paper.title ? (
+                          <PaperCitation paper={paper} headingLevel="h3" linkClassName="text-gray-900 dark:text-gray-100 font-medium" />
+                        ) : (
+                          <Link
+                            href={paper.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors"
+                          >
+                            {displayName}
+                          </Link>
+                        )}
+                      </div>
+                      <span className="ml-4 text-blue-600 dark:text-blue-400 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
                         <svg
                           className="w-5 h-5"
                           fill="none"
@@ -59,7 +67,7 @@ export default async function Publications() {
                           />
                         </svg>
                       </span>
-                    </Link>
+                    </div>
                   </div>
                 );
               })}

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { PaperCitation } from '@/components/PaperCitation';
 import { getFeaturedPapers } from '@/lib/papers';
 
 const researchAreas = [
@@ -90,14 +91,24 @@ export default function ResearchPage() {
           <div className="grid md:grid-cols-2 gap-8">
             {featuredPublications.map((pub) => (
               <div key={pub.filename} className="bg-gray-50 dark:bg-gray-800 rounded-lg shadow-lg p-6">
-                <h3 className="font-semibold text-lg text-gray-900 dark:text-gray-100 mb-2">
-                  <Link href={pub.url} className="hover:text-blue-600 dark:hover:text-blue-400">
-                    {pub.name}
-                  </Link>
-                </h3>
-                {pub.year ? (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">{pub.year}</p>
-                ) : null}
+                {pub.title ? (
+                  <PaperCitation
+                    paper={pub}
+                    headingLevel="h3"
+                    linkClassName="font-semibold text-lg text-gray-900 dark:text-gray-100 mb-2"
+                  />
+                ) : (
+                  <>
+                    <h3 className="font-semibold text-lg text-gray-900 dark:text-gray-100 mb-2">
+                      <Link href={pub.url} className="hover:text-blue-600 dark:hover:text-blue-400">
+                        {pub.name}
+                      </Link>
+                    </h3>
+                    {pub.year ? (
+                      <p className="text-sm text-gray-500 dark:text-gray-400">{pub.year}</p>
+                    ) : null}
+                  </>
+                )}
               </div>
             ))}
           </div>

--- a/components/PaperCitation.tsx
+++ b/components/PaperCitation.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import {
+  getPaperDisplayName,
+  getPaperDoiUrl,
+  type Paper,
+} from '@/lib/papers';
+
+interface PaperCitationProps {
+  paper: Paper;
+  headingLevel?: 'h3' | 'span';
+  linkClassName?: string;
+}
+
+export const PaperCitation = ({
+  paper,
+  headingLevel = 'span',
+  linkClassName = '',
+}: PaperCitationProps) => {
+  const Heading = headingLevel;
+  const displayName = getPaperDisplayName(paper);
+  const citationParts = [
+    paper.journal ? paper.journal : paper.book,
+    paper.year ? String(paper.year) : null,
+  ].filter(Boolean);
+
+  return (
+    <div>
+      <Heading className={linkClassName}>
+        <Link
+          href={paper.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-blue-600 dark:hover:text-blue-400"
+        >
+          {displayName}
+        </Link>
+      </Heading>
+      {paper.authors?.length ? (
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          {paper.authors.join(', ')}
+        </p>
+      ) : null}
+      {citationParts.length > 0 ? (
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {citationParts.join(', ')}
+        </p>
+      ) : null}
+      {paper.doi ? (
+        <p className="mt-2 text-sm">
+          <Link
+            href={getPaperDoiUrl(paper.doi)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            DOI
+          </Link>
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/components/PaperCitation.tsx
+++ b/components/PaperCitation.tsx
@@ -25,12 +25,12 @@ export const PaperCitation = ({
 
   return (
     <div>
-      <Heading className={linkClassName}>
+      <Heading>
         <Link
           href={paper.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-blue-600 dark:hover:text-blue-400"
+          className={`hover:text-blue-600 dark:hover:text-blue-400${linkClassName ? ` ${linkClassName}` : ''}`}
         >
           {displayName}
         </Link>

--- a/data/papers.json
+++ b/data/papers.json
@@ -1,0 +1,59 @@
+{
+  "Spaet, Mourier, and Rummer 2026.pdf": {
+    "title": "Inclusive Science for a changing ocean: gender equity in elasmobranch research",
+    "authors": ["Julia L. Y. Spaet", "Johann Mourier", "Jodie L. Rummer"],
+    "year": 2026,
+    "journal": "Frontiers in Fish Science",
+    "volume": "4",
+    "doi": "10.3389/frish.2026.1816786",
+    "published": "2026-08-14",
+    "abstract": "Persistent inequities in marine science continue to shape who leads research, whose work is most visible, and which questions are prioritised. In elasmobranch science, a field often defined by intensive fieldwork and long-standing cultural norms, these dynamics have direct consequences for scientific capacity and conservation outcomes. Drawing on a decade of global publication data alongside existing scholarship, this Perspective evaluates how gender representation has changed within elasmobranch research and where structural barriers remain. Authorship patterns across more than twelve thousand peer reviewed publications indicate meaningful gains in participation by women, particularly at early career stages and in lead authorship. Progression into sustained senior authorship position remains uneven, reflecting institutional and cultural constraints rather than lack of expertise. These patterns align with broader evidence of leaky career pathways that continue to privilege narrow models of authority. Rather than framing equity as a matter of representation alone, we argue that inclusion is fundamental to the intellectual robustness of elasmobranch science. Diverse leadership expands the scope of inquiry, strengthens collaboration, and improves conservation relevance. As pressures on shark and ray populations intensify, retaining and empowering diverse scientific talent is not optional. It is essential. We call for coordinated structural reform across institutions, funding systems, publishing practices, and field operations to ensure that elasmobranch science reflects the diversity of expertise required to meet accelerating ocean challenges."
+  },
+  "Debaere et al., 2025 J Fish Biology.pdf": {
+    "title": "The costs and healing rates of minor injuries in neonatal reef sharks",
+    "authors": [
+      "Shamil F. Debaere",
+      "Ornella C. Weideli",
+      "Ryan Daly",
+      "Elena M. C. Milanesi",
+      "José E. Trujillo",
+      "Ian A. Bouyoucos",
+      "Johann Mourier",
+      "Andrew Chin",
+      "Serge Planes",
+      "Gudrun De Boeck",
+      "Jodie L. Rummer"
+    ],
+    "year": 2025,
+    "journal": "Journal of Fish Biology",
+    "doi": "10.1111/jfb.16059"
+  },
+  "Dubuc et al., 2025 JEB.pdf": {
+    "title": "Harnessing physiological research for smarter environmental policy",
+    "authors": [
+      "Alexia Dubuc",
+      "Courtney M. Burns",
+      "Shamil F. Debaere",
+      "Carmen Dobszewicz",
+      "Joel H. Gayford",
+      "Jodie L. Rummer"
+    ],
+    "year": 2025,
+    "journal": "Journal of Experimental Biology",
+    "doi": "10.1242/jeb.249867"
+  },
+  "Gayford and Rummer, 2025 Reviews in Fish Biology and Fisheries.pdf": {
+    "title": "Tonic immobility in cartilaginous fishes (Chondrichthyes): function, evolutionary history, and future directions",
+    "authors": ["Joel H. Gayford", "Jodie L. Rummer"],
+    "year": 2025,
+    "journal": "Reviews in Fish Biology and Fisheries",
+    "doi": "10.1007/s11160-025-09958-3"
+  },
+  "Wheeler et al., 2025 Biology Open.pdf": {
+    "title": "Assessing the metabolic and physiological costs of oviparity in the epaulette shark (Hemiscyllium ocellatum)",
+    "authors": ["Carolyn R. Wheeler", "Cynthia A. Awruch", "John W. Mandelman", "Jodie L. Rummer"],
+    "year": 2025,
+    "journal": "Biology Open",
+    "doi": "10.1242/bio.062076"
+  }
+}

--- a/data/papers.ts
+++ b/data/papers.ts
@@ -1,0 +1,24 @@
+import papersJson from './papers.json';
+
+export interface PaperMetadataRecord {
+  title: string;
+  authors: string[];
+  year?: number;
+  journal?: string;
+  book?: string;
+  doi?: string;
+  abstract?: string;
+  published?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
+}
+
+export type PaperMetadataByFilename = Record<string, PaperMetadataRecord>;
+
+const paperMetadata = papersJson as PaperMetadataByFilename;
+
+export const getPaperMetadataByFilename = (): PaperMetadataByFilename => paperMetadata;
+
+export const getPaperMetadata = (filename: string): PaperMetadataRecord | undefined =>
+  paperMetadata[filename];

--- a/lib/papers.ts
+++ b/lib/papers.ts
@@ -1,11 +1,22 @@
 import fs from 'fs';
 import path from 'path';
+import { getPaperMetadata, type PaperMetadataRecord } from '@/data/papers';
 
 export interface Paper {
   filename: string;
   name: string;
   year: number | null;
   url: string;
+  title?: string;
+  authors?: string[];
+  journal?: string;
+  book?: string;
+  doi?: string;
+  abstract?: string;
+  published?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
 }
 
 export interface PapersPage {
@@ -22,12 +33,18 @@ export const getYearFromFilename = (filename: string): number | null => {
   return match ? Number(match[0]) : null;
 };
 
+export const getPaperDisplayName = (paper: Pick<Paper, 'title' | 'name'>): string =>
+  paper.title ?? paper.name;
+
+export const getPaperDoiUrl = (doi: string): string =>
+  doi.startsWith('http') ? doi : `https://doi.org/${doi}`;
+
 const comparePapers = (a: Paper, b: Paper): number => {
   const yearDiff = (b.year ?? 0) - (a.year ?? 0);
   if (yearDiff !== 0) {
     return yearDiff;
   }
-  return a.name.localeCompare(b.name);
+  return getPaperDisplayName(a).localeCompare(getPaperDisplayName(b));
 };
 
 const toPaperUrl = (filename: string, origin?: string): string => {
@@ -36,6 +53,32 @@ const toPaperUrl = (filename: string, origin?: string): string => {
     return `${origin}/papers/${encoded}`;
   }
   return `/papers/${encoded}`;
+};
+
+const mergePaperMetadata = (
+  filename: string,
+  metadata: PaperMetadataRecord | undefined,
+  options?: { origin?: string },
+): Paper => {
+  const name = filename.replace(/\.pdf$/i, '');
+  const year = metadata?.year ?? getYearFromFilename(filename);
+
+  return {
+    filename,
+    name,
+    year,
+    url: toPaperUrl(filename, options?.origin),
+    ...(metadata?.title ? { title: metadata.title } : {}),
+    ...(metadata?.authors?.length ? { authors: metadata.authors } : {}),
+    ...(metadata?.journal ? { journal: metadata.journal } : {}),
+    ...(metadata?.book ? { book: metadata.book } : {}),
+    ...(metadata?.doi ? { doi: metadata.doi } : {}),
+    ...(metadata?.abstract ? { abstract: metadata.abstract } : {}),
+    ...(metadata?.published ? { published: metadata.published } : {}),
+    ...(metadata?.volume ? { volume: metadata.volume } : {}),
+    ...(metadata?.issue ? { issue: metadata.issue } : {}),
+    ...(metadata?.pages ? { pages: metadata.pages } : {}),
+  };
 };
 
 export const getPapers = (options?: { origin?: string }): Paper[] => {
@@ -48,12 +91,7 @@ export const getPapers = (options?: { origin?: string }): Paper[] => {
   return fs
     .readdirSync(papersDirectory)
     .filter((file) => file.toLowerCase().endsWith('.pdf'))
-    .map((filename) => ({
-      filename,
-      name: filename.replace(/\.pdf$/i, ''),
-      year: getYearFromFilename(filename),
-      url: toPaperUrl(filename, options?.origin),
-    }))
+    .map((filename) => mergePaperMetadata(filename, getPaperMetadata(filename), options))
     .sort(comparePapers);
 };
 


### PR DESCRIPTION
## Summary
- Adds `data/papers.json` keyed by PDF filename with title, authors, year, journal, DOI, and optional abstract.
- Merges citation metadata into `GET /api/papers` and `GET /api/papers/featured` via `lib/papers.ts`.
- Seeds metadata for the Spaet/Mourier/Rummer 2026 paper and four 2025 podcast papers.
- Shows rich citations on `/publications` and `/research` when metadata exists; PDFs without entries keep filename-based fallbacks.

Closes #195

## Test plan
- [ ] `npm run lint` and `npm run build` pass
- [ ] `GET /api/papers` returns `title`, `authors`, `journal`, and `doi` for Spaet 2026
- [ ] `/publications` shows full citation for seeded papers and filename fallback for others
- [ ] `/research` featured section shows citation details for seeded papers
- [ ] After deploy, jodierummer can consume enriched API fields (follow-up PR on jodierummer)